### PR TITLE
feat(shell): add floating Open Settings control with full-screen Sett…

### DIFF
--- a/src/components/AuthenticatedShell.tsx
+++ b/src/components/AuthenticatedShell.tsx
@@ -6,6 +6,7 @@ import { Show, createResource } from 'solid-js';
 import type { ConnectionState } from '../bindings';
 import { fetchConnectionState } from '../effects/connection';
 import NowPlayingDrawer from './NowPlayingDrawer';
+import SettingsModal from './SettingsModal';
 import { ConsoleShell } from './ui';
 
 const navItems: {
@@ -132,6 +133,9 @@ export default function AuthenticatedShell() {
         <main class="min-w-0 animate-[fadeIn_0.3s_cubic-bezier(0.16,1,0.3,1)_forwards]">
           <Outlet />
         </main>
+      </div>
+      <div class="fixed right-4 bottom-4 z-40 flex flex-col items-end gap-3">
+        <SettingsModal />
       </div>
     </ConsoleShell>
   );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,91 @@
+import { useNavigate } from '@tanstack/solid-router';
+import { Settings, X } from 'lucide-solid';
+import { Show, createEffect, createSignal, onCleanup } from 'solid-js';
+
+import OperationsConsole from './OperationsConsole';
+import { Button } from './ui';
+
+const SETTINGS_TITLE_ID = 'settings-dialog-title';
+const SETTINGS_DESC_ID = 'settings-dialog-description';
+
+export default function SettingsModal() {
+  const [open, setOpen] = createSignal(false);
+  const navigate = useNavigate();
+  let panelRef: HTMLElement | undefined;
+
+  createEffect(() => {
+    if (!open()) {
+      return;
+    }
+    const node = panelRef;
+    if (!node) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    node.addEventListener('keydown', onKeyDown);
+    queueMicrotask(() => node.focus());
+    onCleanup(() => node.removeEventListener('keydown', onKeyDown));
+  });
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="primary"
+        size="lg"
+        aria-label="Open Settings"
+        aria-expanded={open()}
+        onClick={() => setOpen(true)}
+        class="shadow-primary/45 shadow-2xl"
+      >
+        <Settings class="h-5 w-5" />
+        <span>Settings</span>
+      </Button>
+      <Show when={open()}>
+        <div
+          ref={(el) => {
+            panelRef = el;
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={SETTINGS_TITLE_ID}
+          aria-describedby={SETTINGS_DESC_ID}
+          tabindex={-1}
+          class="border-outline-variant/30 bg-surface-container-low/60 fixed inset-0 z-40 flex h-full w-full animate-[fadeIn_0.3s_cubic-bezier(0.16,1,0.3,1)_forwards] flex-col overflow-hidden backdrop-blur-xl outline-none"
+        >
+          <header class="border-outline-variant/40 bg-surface-container-low/70 flex items-center justify-between gap-3 border-b px-5 py-4 backdrop-blur-xl">
+            <div>
+              <h2
+                id={SETTINGS_TITLE_ID}
+                class="text-on-surface text-[22px] leading-[28px] font-bold"
+              >
+                Settings
+              </h2>
+              <p
+                id={SETTINGS_DESC_ID}
+                class="text-on-surface-variant/70 mt-0.5 text-[12px] leading-[16px]"
+              >
+                Connection, player bridge, diagnostics, shortcuts, and session controls
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="icon"
+              aria-label="Close Settings"
+              onClick={() => setOpen(false)}
+            >
+              <X class="h-5 w-5" />
+            </Button>
+          </header>
+          <div class="min-h-0 flex-1 overflow-y-auto">
+            <OperationsConsole onSignedOut={() => navigate({ to: '/login' })} />
+          </div>
+        </div>
+      </Show>
+    </>
+  );
+}

--- a/tests/app-shell.test.tsx
+++ b/tests/app-shell.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, expect, rstest, test } from '@rstest/core';
 import { RouterProvider, createMemoryHistory } from '@tanstack/solid-router';
-import { fireEvent, screen, waitFor } from '@testing-library/dom';
+import { fireEvent, screen, waitFor, within } from '@testing-library/dom';
 import { render } from 'solid-js/web';
 
 import { commands, events } from '../src/bindings';
@@ -1037,6 +1037,94 @@ test('now playing drawer exposes full playback controls', async () => {
   expect(screen.getByRole('dialog', { name: 'Now Playing' })).toBeVisible();
   fireEvent.click(screen.getByRole('button', { name: 'Close Now Playing' }));
   await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Now Playing' })).toBeNull());
+
+  cleanup();
+});
+
+test('floating Open Settings control opens Settings modal with operations console content', async () => {
+  mockShellCommands();
+  const cleanup = renderShell('/library');
+
+  await screen.findByRole('navigation', { name: 'Library navigation' });
+
+  const trigger = await screen.findByRole('button', { name: 'Open Settings' });
+  expect(trigger).toBeVisible();
+  fireEvent.click(trigger);
+
+  const settings = await screen.findByRole('dialog', { name: 'Settings' });
+  expect(settings).toBeVisible();
+  expect(
+    within(settings).getByText(
+      'Connection, player bridge, diagnostics, shortcuts, and session controls',
+    ),
+  ).toBeVisible();
+  expect(within(settings).getByRole('heading', { name: 'Connection' })).toBeVisible();
+  expect(within(settings).getByRole('heading', { name: 'Player Bridge settings' })).toBeVisible();
+  expect(within(settings).getByRole('heading', { name: 'Diagnostics' })).toBeVisible();
+  expect(within(settings).getByText('0 sanitized runtime events')).toBeVisible();
+
+  cleanup();
+});
+
+test('Close Settings and standard dismissal close the Settings modal back to the Library Browser', async () => {
+  mockShellCommands();
+  const cleanup = renderShell('/library');
+
+  await screen.findByRole('navigation', { name: 'Library navigation' });
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Open Settings' }));
+  const settings = await screen.findByRole('dialog', { name: 'Settings' });
+  expect(settings).toBeVisible();
+  fireEvent.click(screen.getByRole('button', { name: 'Close Settings' }));
+  await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull());
+
+  // Standard dialog dismissal (Escape) via the headless primitive
+  fireEvent.click(screen.getByRole('button', { name: 'Open Settings' }));
+  const reopened = await screen.findByRole('dialog', { name: 'Settings' });
+  fireEvent.keyDown(reopened, { code: 'Escape', key: 'Escape' });
+  await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull());
+
+  // The Library Browser remains the active authenticated surface after closing
+  expect(screen.getByRole('navigation', { name: 'Library navigation' })).toBeVisible();
+
+  cleanup();
+});
+
+test('Sign out from the Settings modal reaches Login and stays distinct from Disconnect', async () => {
+  mockShellCommands();
+  let connected = true;
+  rstest
+    .spyOn(commands, 'jellyfinIsConnected')
+    .mockImplementation(() => Promise.resolve(connected));
+  rstest.spyOn(commands, 'jellyfinClearSession').mockImplementation(() => {
+    connected = false;
+    return Promise.resolve({ data: null, status: 'ok' });
+  });
+  localStorage.setItem('jmsr_auth_session', JSON.stringify({ serverUrl: 'https://jmsr.example' }));
+
+  const cleanup = renderShell('/library');
+  await screen.findByRole('navigation', { name: 'Library navigation' });
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Open Settings' }));
+  const settings = await screen.findByRole('dialog', { name: 'Settings' });
+
+  // Disconnect and Sign out are both present and distinct inside Settings
+  expect(within(settings).getByRole('button', { name: 'Disconnect' })).toBeVisible();
+  expect(within(settings).getByRole('button', { name: 'Sign out' })).toBeVisible();
+
+  // Open the sign-out confirmation dialog (nested Ark dialog) and confirm sign out
+  fireEvent.click(within(settings).getByRole('button', { name: 'Sign out' }));
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible());
+  const confirmDialog = screen
+    .getByRole('button', { name: 'Cancel' })
+    .closest('[role="dialog"]') as HTMLElement;
+  fireEvent.click(within(confirmDialog).getByRole('button', { name: 'Sign out' }));
+
+  // Sign out clears the Saved Session and reaches Login
+  await waitFor(() => expect(localStorage.getItem('jmsr_auth_session')).toBeNull());
+  expect(
+    await screen.findByPlaceholderText('jellyfin.local or media.example.com/jellyfin'),
+  ).toBeVisible();
 
   cleanup();
 });


### PR DESCRIPTION
floating modal

Add a bottom-right floating control to the authenticated shell that opens a full-screen Settings overlay hosting the existing Operations Console (Connection, Player Bridge, Diagnostics, Intro Skip, Shortcut keys, Session, footer). The overlay exposes role="dialog" with the accessible name "Settings", the description "Connection, player bridge, diagnostics, shortcuts, and session controls", an explicit Close Settings control, and Escape dismissal. Sign out from the modal reaches Login; Disconnect stays distinct; the existing header stays intact for this slice.

Settings is a controlled ARIA dialog overlay rather than an Ark Dialog: nesting OperationsConsole (whose SessionCard owns its own Ark sign-out dialog) inside an Ark Dialog through the router prevents the sign-out confirm from opening, so the overlay keeps OperationsConsole's Ark dialog as the sole dialog layer. No raw Tauri commands are added; the shell still loads connection state through the typed frontend workflow.

Closes #79