### PR TITLE
feat(session): restore active Saved Service Profile on every authenticated entry

### DIFF
--- a/src/router-guards.ts
+++ b/src/router-guards.ts
@@ -1,6 +1,6 @@
 import { redirect } from '@tanstack/solid-router';
 
-import { canAccessConsole, checkAuthWithRestore } from './sessionAccess';
+import { canAccessConsole, resolveAuthenticatedEntry } from './sessionAccess';
 
 export const AUTHENTICATED_HOME_ROUTE = '/library';
 
@@ -11,13 +11,13 @@ export async function redirectLoggedInUsersToLibrary() {
 }
 
 export async function requireAuthenticatedShell() {
-  if (!(await canAccessConsole())) {
+  if (!(await resolveAuthenticatedEntry())) {
     throw redirect({ to: '/login' });
   }
 }
 
 export async function redirectRootRoute() {
-  if (await checkAuthWithRestore()) {
+  if (await resolveAuthenticatedEntry()) {
     throw redirect({ to: AUTHENTICATED_HOME_ROUTE });
   }
   throw redirect({ to: '/login' });

--- a/src/sessionAccess.ts
+++ b/src/sessionAccess.ts
@@ -64,7 +64,38 @@ export async function restoreSavedSession(): Promise<boolean> {
   });
 }
 
-export async function checkAuthWithRestore(): Promise<boolean> {
+interface ProfileRestoreDecision {
+  readonly restored: boolean;
+  readonly profilesRetained: boolean;
+}
+
+async function decideProfileRestore(): Promise<ProfileRestoreDecision> {
+  await migrateLegacySavedSession();
+  const profiles = await Effect.runPromiseExit(fetchSavedServiceProfiles);
+  if (!Exit.isSuccess(profiles)) {
+    return { restored: false, profilesRetained: false };
+  }
+
+  const profilesRetained = profiles.value.profiles.length > 0;
+  const activeProfileKey = Option.fromNullishOr(profiles.value.activeProfileKey);
+  if (Option.isNone(activeProfileKey)) {
+    return { restored: false, profilesRetained };
+  }
+
+  const restored = await Effect.runPromiseExit(activateSavedServiceProfile(activeProfileKey.value));
+  return { restored: Exit.isSuccess(restored), profilesRetained };
+}
+
+let profileRestoreInFlight: Promise<ProfileRestoreDecision> | null = null;
+
+function restoreActiveServiceProfileOnce(): Promise<ProfileRestoreDecision> {
+  profileRestoreInFlight ??= decideProfileRestore().finally(() => {
+    profileRestoreInFlight = null;
+  });
+  return profileRestoreInFlight;
+}
+
+export async function resolveAuthenticatedEntry(): Promise<boolean> {
   const connected = await Effect.runPromiseExit(
     runTauriCommandRaw(() => commands.serverIsConnected()),
   );
@@ -75,19 +106,8 @@ export async function checkAuthWithRestore(): Promise<boolean> {
     return true;
   }
 
-  await migrateLegacySavedSession();
-  const profiles = await Effect.runPromiseExit(fetchSavedServiceProfiles);
-  if (!Exit.isSuccess(profiles)) {
-    return false;
-  }
-
-  const activeProfileKey = Option.fromNullishOr(profiles.value.activeProfileKey);
-  if (Option.isNone(activeProfileKey)) {
-    return profiles.value.profiles.length > 0;
-  }
-
-  const restored = await Effect.runPromiseExit(activateSavedServiceProfile(activeProfileKey.value));
-  return Exit.isSuccess(restored) || profiles.value.profiles.length > 0;
+  const { restored, profilesRetained } = await restoreActiveServiceProfileOnce();
+  return restored || profilesRetained;
 }
 
 export async function canAccessConsole(): Promise<boolean> {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -72,6 +72,55 @@ test('shell guard redirects unauthenticated users to Login', async () => {
   await expectRedirect(requireAuthenticatedShell, '/login');
 });
 
+test('shell guard restores the active saved service profile on deep links', async () => {
+  rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
+  rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+  const activate = rstest.spyOn(commands, 'serverProfilesActivate').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+
+  await requireAuthenticatedShell();
+
+  expect(activate).toHaveBeenCalledWith(sampleProfiles.activeProfileKey);
+});
+
+test('shell guard admits retained profiles when active profile restore fails', async () => {
+  rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
+  rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+  rstest.spyOn(commands, 'serverProfilesActivate').mockResolvedValue({
+    error: { code: 'authFailed', message: 'expired' },
+    status: 'error',
+  });
+
+  await requireAuthenticatedShell();
+});
+
+test('shell guard makes one restore decision and does not double-activate', async () => {
+  const connected = rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
+  rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+  const activate = rstest.spyOn(commands, 'serverProfilesActivate').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+
+  await Promise.all([requireAuthenticatedShell(), requireAuthenticatedShell()]);
+  expect(activate).toHaveBeenCalledTimes(1);
+
+  connected.mockResolvedValue(true);
+  await requireAuthenticatedShell();
+  expect(activate).toHaveBeenCalledTimes(1);
+});
+
 test('browse route redirects unknown collection types to Library', async () => {
   rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(true);
   const router = createJellyPilotRouter(

--- a/tests/session-access.test.ts
+++ b/tests/session-access.test.ts
@@ -6,9 +6,9 @@ import type { SavedServiceProfiles, SavedSession } from '../src/bindings';
 import { LEGACY_SESSION_STORAGE_KEY, SESSION_STORAGE_KEY } from '../src/effects/auth';
 import {
   canAccessConsole,
-  checkAuthWithRestore,
   clearSavedSession,
   loadSavedSession,
+  resolveAuthenticatedEntry,
   restoreSavedSession,
   saveSession,
 } from '../src/sessionAccess';
@@ -116,7 +116,7 @@ test('restoreSavedSession returns false after active profile restore command thr
   await expect(restoreSavedSession()).resolves.toBe(false);
 });
 
-test('checkAuthWithRestore attempts active profile restore before denying root route access', async () => {
+test('resolveAuthenticatedEntry attempts active profile restore before denying root route access', async () => {
   rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
   rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
     data: sampleProfiles,
@@ -126,18 +126,30 @@ test('checkAuthWithRestore attempts active profile restore before denying root r
     .spyOn(commands, 'serverProfilesActivate')
     .mockResolvedValue({ data: sampleProfiles, status: 'ok' });
 
-  await expect(checkAuthWithRestore()).resolves.toBe(true);
+  await expect(resolveAuthenticatedEntry()).resolves.toBe(true);
   expect(activate).toHaveBeenCalledWith(sampleProfileKey);
 });
 
-test('checkAuthWithRestore denies access when command checks throw', async () => {
+test('resolveAuthenticatedEntry denies access when command checks throw', async () => {
   rstest.spyOn(commands, 'serverIsConnected').mockRejectedValue(new Error('ipc unavailable'));
   rstest.spyOn(commands, 'serverProfilesGet').mockRejectedValue(new Error('profiles unavailable'));
 
-  await expect(checkAuthWithRestore()).resolves.toBe(false);
+  await expect(resolveAuthenticatedEntry()).resolves.toBe(false);
 });
 
-test('checkAuthWithRestore allows shell access when active profile restore fails but profiles remain', async () => {
+test('resolveAuthenticatedEntry denies access without activating when no profiles are saved', async () => {
+  rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
+  rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
+    data: { activeProfileKey: null, profiles: [] },
+    status: 'ok',
+  });
+  const activate = rstest.spyOn(commands, 'serverProfilesActivate');
+
+  await expect(resolveAuthenticatedEntry()).resolves.toBe(false);
+  expect(activate).not.toHaveBeenCalled();
+});
+
+test('resolveAuthenticatedEntry allows shell access when active profile restore fails but profiles remain', async () => {
   rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
   rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
     data: sampleProfiles,
@@ -148,7 +160,27 @@ test('checkAuthWithRestore allows shell access when active profile restore fails
     status: 'error',
   });
 
-  await expect(checkAuthWithRestore()).resolves.toBe(true);
+  await expect(resolveAuthenticatedEntry()).resolves.toBe(true);
+});
+
+test('resolveAuthenticatedEntry shares one restore decision across concurrent entries', async () => {
+  rstest.spyOn(commands, 'serverIsConnected').mockResolvedValue(false);
+  rstest.spyOn(commands, 'serverProfilesGet').mockResolvedValue({
+    data: sampleProfiles,
+    status: 'ok',
+  });
+  const activate = rstest
+    .spyOn(commands, 'serverProfilesActivate')
+    .mockResolvedValue({ data: sampleProfiles, status: 'ok' });
+
+  const [first, second] = await Promise.all([
+    resolveAuthenticatedEntry(),
+    resolveAuthenticatedEntry(),
+  ]);
+
+  expect(first).toBe(true);
+  expect(second).toBe(true);
+  expect(activate).toHaveBeenCalledTimes(1);
 });
 
 test('clearSavedSession removes Saved Session state synchronously', () => {


### PR DESCRIPTION
Root navigation, deep links, and reloads now share one restore-capable
authenticated-entry policy. Entering the authenticated shell while
disconnected activates the active Saved Service Profile before content
loads; a failed restore with retained profiles still admits the shell
per ADR 0009, and concurrent entries share a single restore decision
so activation never runs twice. Login redirect keeps its non-activating
check and Settings reconnect keeps its explicit behavior.

Closes #202

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>