### PR TITLE
feat(shell): own connection identity and local readiness in one bootstrap module

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -4,18 +4,13 @@ import { Link, useLocation, useParams } from '@tanstack/solid-router';
 import { Exit } from 'effect';
 import { Film, House, PanelLeftClose, PanelLeftOpen, Tv } from 'lucide-solid';
 import { For, Show, createMemo, type JSX } from 'solid-js';
-import { fetchConnectionState } from '~effects/connection';
 import { fetchLibraryShortcuts, fetchVideoItemShortcut } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { isLibrarySessionKeyConnected, queryKeys, runExit } from '~effects/query';
 import { createSidebarPreferences } from '~utils/sidebarPreferences';
 import { createSidebarWipe, startSidebarWipe } from '~utils/sidebarWipe';
 
 import * as styles from './AppSidebar.styles';
+import { useAuthenticatedBootstrap } from './AuthenticatedBootstrap';
 import { LibraryImage } from './library/LibraryImage';
 import NowPlayingDrawer from './NowPlayingDrawer';
 import SettingsModal from './SettingsModal';
@@ -37,12 +32,8 @@ interface SidebarShortcutItem {
 export default function AppSidebar(props: AppSidebarProps) {
   const { collapsed, setCollapsed } = createSidebarPreferences();
   const { wipe } = createSidebarWipe();
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
   const shortcutsQuery = createQuery(() => ({
     queryKey: queryKeys.libraryShortcuts(sessionKey()),
     enabled: isLibrarySessionKeyConnected(sessionKey()),

--- a/src/components/AuthenticatedBootstrap.tsx
+++ b/src/components/AuthenticatedBootstrap.tsx
@@ -1,0 +1,86 @@
+import { createQuery, useQueryClient } from '@tanstack/solid-query';
+import { Effect, Exit } from 'effect';
+import { type JSX, createContext, createEffect, createMemo, onMount, useContext } from 'solid-js';
+import { fetchConnectionState } from '~effects/connection';
+import { fetchAppLocalServices } from '~effects/localServices';
+import {
+  isLibrarySessionKeyConnected,
+  librarySessionKeyFromConnectionExit,
+  librarySessionSignature,
+  queryKeys,
+  runExit,
+} from '~effects/query';
+import type { LibrarySessionKey } from '~effects/query';
+import { setImageProxyBase } from '~utils/imageSource';
+
+/**
+ * Shell-level bootstrap read model: the single connection-state observer for
+ * the authenticated shell plus application-local readiness. Sidebar, Video
+ * Home, and Library Browser consume this context instead of mounting their
+ * own connection observers.
+ */
+export interface AuthenticatedBootstrap {
+  readonly sessionKey: () => LibrarySessionKey;
+  readonly connected: () => boolean;
+}
+
+const AuthenticatedBootstrapContext = createContext<AuthenticatedBootstrap>();
+
+export function useAuthenticatedBootstrap(): AuthenticatedBootstrap {
+  const context = useContext(AuthenticatedBootstrapContext);
+  if (!context) {
+    throw new Error('useAuthenticatedBootstrap must be used within AuthenticatedBootstrapProvider');
+  }
+  return context;
+}
+
+export interface AuthenticatedBootstrapProviderProps {
+  /** Invoked after a connected Saved Service Profile switch replaces the session identity. */
+  readonly onSessionChange?: () => void;
+  readonly children: JSX.Element;
+}
+
+export function AuthenticatedBootstrapProvider(props: AuthenticatedBootstrapProviderProps) {
+  const queryClient = useQueryClient();
+  const connectionQuery = createQuery(() => ({
+    queryKey: queryKeys.connectionState,
+    queryFn: () => runExit(fetchConnectionState),
+    staleTime: Infinity,
+  }));
+  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const connected = () => isLibrarySessionKeyConnected(sessionKey());
+
+  onMount(() => {
+    void Effect.runPromiseExit(fetchAppLocalServices).then((exit) =>
+      Exit.match(exit, {
+        onFailure: () => setImageProxyBase(null),
+        onSuccess: (services) => setImageProxyBase(services?.imageProxyBase ?? null),
+      }),
+    );
+  });
+
+  let mountedSessionSignature: string | null = null;
+  createEffect(() => {
+    const currentSessionKey = sessionKey();
+    const currentSignature = librarySessionSignature(currentSessionKey);
+    if (currentSignature === null) {
+      return;
+    }
+
+    const previousSignature = mountedSessionSignature;
+    mountedSessionSignature = currentSignature;
+    if (previousSignature === null || previousSignature === currentSignature) {
+      return;
+    }
+
+    queryClient.removeQueries({ queryKey: queryKeys.libraryRoot });
+    props.onSessionChange?.();
+  });
+
+  const value: AuthenticatedBootstrap = { sessionKey, connected };
+  return (
+    <AuthenticatedBootstrapContext.Provider value={value}>
+      {props.children}
+    </AuthenticatedBootstrapContext.Provider>
+  );
+}

--- a/src/components/library/MediaInfoHoverCard.tsx
+++ b/src/components/library/MediaInfoHoverCard.tsx
@@ -1,20 +1,15 @@
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import { HoverCard } from '@components/ui';
 import { cx } from '@styled-system/css';
 import { createQuery } from '@tanstack/solid-query';
 import { Exit, Option } from 'effect';
 import { Check, Heart, LoaderCircle } from 'lucide-solid';
-import { createMemo, createSignal, For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import type { JSX } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import { fetchMediaDetail } from '~effects/library';
 import type { MediaDetail } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { queryKeys, runExit } from '~effects/query';
 
 import * as styles from './MediaInfoHoverCard.styles';
 
@@ -104,16 +99,12 @@ export function MediaInfoHoverCard(props: {
   children: JSX.Element;
 }) {
   const [open, setOpen] = createSignal(false);
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
   const detailQuery = createQuery(() => ({
     queryKey: queryKeys.libraryMediaDetail(sessionKey(), props.itemType, props.id),
     queryFn: () => runExit(fetchMediaDetail(props.id, props.itemType)),
-    enabled: open() && isLibrarySessionKeyConnected(sessionKey()),
+    enabled: open() && bootstrap.connected(),
     staleTime: Infinity,
   }));
 

--- a/src/effects/query.ts
+++ b/src/effects/query.ts
@@ -51,6 +51,12 @@ export function isLibrarySessionKeyConnected(sessionKey: LibrarySessionKey) {
   );
 }
 
+export function librarySessionSignature(sessionKey: LibrarySessionKey) {
+  return isLibrarySessionKeyConnected(sessionKey)
+    ? `${sessionKey.provider}\u0000${sessionKey.serverUrl}\u0000${sessionKey.userId}`
+    : null;
+}
+
 export const queryKeys = {
   appVersion: ['app', 'version'] as const,
   appConfig: ['config', 'app'] as const,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,16 +1,14 @@
-import { createQuery } from '@tanstack/solid-query';
-import { Outlet, createFileRoute } from '@tanstack/solid-router';
-import { Effect, Exit } from 'effect';
-import { Show, onMount } from 'solid-js';
-import { setImageProxyBase } from '~utils/imageSource';
+import { Outlet, createFileRoute, useNavigate } from '@tanstack/solid-router';
+import { Show } from 'solid-js';
 import { createSidebarPreferences } from '~utils/sidebarPreferences';
 import { createSidebarWipe } from '~utils/sidebarWipe';
 
 import AppSidebar from '../components/AppSidebar';
-import { fetchConnectionState } from '../effects/connection';
-import { fetchAppLocalServices } from '../effects/localServices';
-import { queryKeys, runExit } from '../effects/query';
-import { requireAuthenticatedShell } from '../router-guards';
+import {
+  AuthenticatedBootstrapProvider,
+  useAuthenticatedBootstrap,
+} from '../components/AuthenticatedBootstrap';
+import { AUTHENTICATED_HOME_ROUTE, requireAuthenticatedShell } from '../router-guards';
 import * as styles from './_authenticated.styles';
 
 export const Route = createFileRoute('/_authenticated')({
@@ -19,23 +17,18 @@ export const Route = createFileRoute('/_authenticated')({
 });
 
 function AuthenticatedShell() {
-  onMount(() => {
-    void Effect.runPromiseExit(fetchAppLocalServices).then((exit) =>
-      Exit.match(exit, {
-        onFailure: () => setImageProxyBase(null),
-        onSuccess: (services) => setImageProxyBase(services?.imageProxyBase ?? null),
-      }),
-    );
-  });
+  const navigate = useNavigate();
+  return (
+    <AuthenticatedBootstrapProvider
+      onSessionChange={() => void navigate({ to: AUTHENTICATED_HOME_ROUTE, replace: true })}
+    >
+      <AuthenticatedShellContent />
+    </AuthenticatedBootstrapProvider>
+  );
+}
 
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-  }));
-  const jellyfinConnected = () =>
-    connectionQuery.data && Exit.isSuccess(connectionQuery.data)
-      ? connectionQuery.data.value.connected
-      : false;
+function AuthenticatedShellContent() {
+  const bootstrap = useAuthenticatedBootstrap();
   const { collapsed } = createSidebarPreferences();
   const { wipe } = createSidebarWipe();
 
@@ -46,7 +39,7 @@ function AuthenticatedShell() {
           <div class={styles.ambientCore} />
         </div>
       </div>
-      <AppSidebar jellyfinConnected={jellyfinConnected()} />
+      <AppSidebar jellyfinConnected={bootstrap.connected()} />
       <Show when={wipe()} keyed>
         {(direction) => (
           <div

--- a/src/routes/_authenticated/library/$collectionType/$libraryId.tsx
+++ b/src/routes/_authenticated/library/$collectionType/$libraryId.tsx
@@ -2,6 +2,7 @@ import { Menu } from '@ark-ui/solid/menu';
 import { Toggle } from '@ark-ui/solid/toggle';
 import type { VideoLibraryKind, VideoLibraryPlayedFilter, VideoLibrarySort } from '@bindings';
 import { useAppScrollArea } from '@components/AppScrollAreaContext';
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import { LibraryVideoCard } from '@components/library/LibraryVideoCard';
 import {
   LibraryStatusPanel,
@@ -12,8 +13,8 @@ import {
 import LibrarySearchBar from '@components/LibrarySearchBar';
 import { Button } from '@components/ui';
 import { cx } from '@styled-system/css';
-import { createInfiniteQuery, createQuery, useQueryClient } from '@tanstack/solid-query';
-import { createFileRoute, redirect, useNavigate } from '@tanstack/solid-router';
+import { createInfiniteQuery, useQueryClient } from '@tanstack/solid-query';
+import { createFileRoute, redirect } from '@tanstack/solid-router';
 import { createVirtualizer, observeElementRect } from '@tanstack/solid-virtual';
 import { Exit } from 'effect';
 import {
@@ -37,15 +38,9 @@ import {
   onMount,
 } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import { LIBRARY_BROWSE_PAGE_SIZE, fetchVideoLibraryPage } from '~effects/library';
 import type { LibraryBrowseState, LibraryExit } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { librarySessionSignature, queryKeys, runExit } from '~effects/query';
 import type { LibrarySessionKey } from '~effects/query';
 import * as recipes from '~styles/recipes';
 import { createSharedLibraryFilters } from '~utils/createSharedLibraryFilters';
@@ -87,7 +82,6 @@ export const Route = createFileRoute('/_authenticated/library/$collectionType/$l
 function LibraryBrowseRoute() {
   const params = Route.useParams();
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const libraryFilters = createSharedLibraryFilters();
   const filterSort = libraryFilters.sort;
   const [autoLoadSentinel, setAutoLoadSentinel] = createSignal<HTMLDivElement | null>(null);
@@ -103,51 +97,22 @@ function LibraryBrowseRoute() {
   );
   const [virtualPageStartsFetching, setVirtualPageStartsFetching] = createSignal(new Set<number>());
   onMount(() => setVirtualizerMounted(true));
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
-  const activeSessionSignature = createMemo(() => {
-    const currentSessionKey = sessionKey();
-    return isLibrarySessionKeyConnected(currentSessionKey)
-      ? `${currentSessionKey.provider}\u0000${currentSessionKey.serverUrl}\u0000${currentSessionKey.userId}`
-      : null;
-  });
-  const [redirectingForSessionChange, setRedirectingForSessionChange] = createSignal(false);
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
+  const activeSessionSignature = createMemo(() => librarySessionSignature(sessionKey()));
   let mountedSessionSignature: string | null = null;
   const isMountedSessionActive = () => {
     const currentSessionSignature = activeSessionSignature();
     return (
       currentSessionSignature !== null &&
-      !redirectingForSessionChange() &&
       (mountedSessionSignature === null || mountedSessionSignature === currentSessionSignature)
     );
   };
 
   createEffect(() => {
-    if (redirectingForSessionChange()) {
-      return;
-    }
-
     const currentSessionSignature = activeSessionSignature();
-    if (currentSessionSignature === null) {
-      if (mountedSessionSignature !== null) {
-        setRedirectingForSessionChange(true);
-        void navigate({ to: AUTHENTICATED_HOME_ROUTE, replace: true });
-      }
-      return;
-    }
-
-    if (mountedSessionSignature === null) {
+    if (currentSessionSignature !== null && mountedSessionSignature === null) {
       mountedSessionSignature = currentSessionSignature;
-      return;
-    }
-
-    if (mountedSessionSignature !== currentSessionSignature) {
-      setRedirectingForSessionChange(true);
-      void navigate({ to: AUTHENTICATED_HOME_ROUTE, replace: true });
     }
   });
 

--- a/src/routes/_authenticated/library/index.tsx
+++ b/src/routes/_authenticated/library/index.tsx
@@ -1,4 +1,5 @@
 import type { VideoHomeItem, VideoLibraryPlayRequest } from '@bindings';
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import { VideoHomeRow } from '@components/library/shared';
 import LibrarySearchBar from '@components/LibrarySearchBar';
 import { useToast } from '@components/ToastProvider';
@@ -6,16 +7,10 @@ import { cx } from '@styled-system/css';
 import { createMutation, createQuery } from '@tanstack/solid-query';
 import { createFileRoute } from '@tanstack/solid-router';
 import { Exit } from 'effect';
-import { For, Show, createMemo, createSignal } from 'solid-js';
+import { For, Show, createSignal } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import { fetchLibraryHome, startLibraryPlayback } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { queryKeys, runExit } from '~effects/query';
 import { isValidVideoHomeResumePosition } from '~utils/videoHomeLayout';
 
 import * as styles from '../library.styles';
@@ -33,15 +28,11 @@ export const Route = createFileRoute('/_authenticated/library/')({
 
 function LibraryLanding() {
   const { showToast } = useToast();
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
   const homeQuery = createQuery(() => ({
     queryKey: queryKeys.libraryHome(sessionKey()),
-    enabled: isLibrarySessionKeyConnected(sessionKey()),
+    enabled: bootstrap.connected(),
     queryFn: () => runExit(fetchLibraryHome),
   }));
   const home = () =>
@@ -87,33 +78,35 @@ function LibraryLanding() {
       >
         <LibrarySearchBar sessionKey={sessionKey()} />
       </nav>
-      <Show when={!homeQuery.isPending} fallback={<VideoHomeSkeleton />}>
-        <Show when={home()}>
-          {(value) => (
-            <div class={cx(styles.stack, styles.pageGutter)}>
-              <VideoHomeRow
-                id="continue-watching"
-                title="Continue Watching"
-                kind="continueWatching"
-                items={value().continueWatching}
-                resumeBusyId={resumeBusyId()}
-                onResume={(item) => void resumeItem(item)}
-              />
-              <VideoHomeRow id="next-up" title="Next Up" kind="nextUp" items={value().nextUp} />
-              <VideoHomeRow
-                id="latest-movies"
-                title="Latest Movies"
-                kind="latestMovies"
-                items={value().latestMovies}
-              />
-              <VideoHomeRow
-                id="latest-episodes"
-                title="Latest Episodes"
-                kind="latestEpisodes"
-                items={value().latestEpisodes}
-              />
-            </div>
-          )}
+      <Show when={bootstrap.connected()}>
+        <Show when={!homeQuery.isPending} fallback={<VideoHomeSkeleton />}>
+          <Show when={home()}>
+            {(value) => (
+              <div class={cx(styles.stack, styles.pageGutter)}>
+                <VideoHomeRow
+                  id="continue-watching"
+                  title="Continue Watching"
+                  kind="continueWatching"
+                  items={value().continueWatching}
+                  resumeBusyId={resumeBusyId()}
+                  onResume={(item) => void resumeItem(item)}
+                />
+                <VideoHomeRow id="next-up" title="Next Up" kind="nextUp" items={value().nextUp} />
+                <VideoHomeRow
+                  id="latest-movies"
+                  title="Latest Movies"
+                  kind="latestMovies"
+                  items={value().latestMovies}
+                />
+                <VideoHomeRow
+                  id="latest-episodes"
+                  title="Latest Episodes"
+                  kind="latestEpisodes"
+                  items={value().latestEpisodes}
+                />
+              </div>
+            )}
+          </Show>
         </Show>
       </Show>
     </>

--- a/src/routes/_authenticated/library/items/$itemId.tsx
+++ b/src/routes/_authenticated/library/items/$itemId.tsx
@@ -5,6 +5,7 @@ import type {
   VideoPlaybackStreamOption,
   VideoUserDataUpdateRequest,
 } from '@bindings';
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import {
   DetailHero,
   type DetailHeroInfoRow,
@@ -19,21 +20,15 @@ import { createMutation, createQuery, useQueryClient } from '@tanstack/solid-que
 import { createFileRoute, useCanGoBack, useNavigate, useRouter } from '@tanstack/solid-router';
 import { Exit } from 'effect';
 import { Film, Play, RotateCcw, Tv } from 'lucide-solid';
-import { Show, createMemo, createSignal } from 'solid-js';
+import { Show, createSignal } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import {
   fetchVideoItemDetail,
   fetchVideoItemStreams,
   startLibraryPlayback,
   updateLibraryUserData,
 } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { isLibrarySessionKeyConnected, queryKeys, runExit } from '~effects/query';
 
 import { AUTHENTICATED_HOME_ROUTE } from '../../../../router-guards';
 import * as styles from '../detailRoute.styles';
@@ -52,12 +47,8 @@ function LibraryItemDetailRoute() {
   const navigate = useNavigate();
   const canGoBack = useCanGoBack();
   const queryClient = useQueryClient();
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
   const detailQuery = createQuery(() => ({
     queryKey: queryKeys.libraryItemDetail(sessionKey(), params().itemId),
     enabled: isLibrarySessionKeyConnected(sessionKey()),
@@ -102,8 +93,7 @@ function LibraryItemDetailRoute() {
     return current && Exit.isSuccess(current) ? current.value : null;
   };
   const detailPending = () =>
-    connectionQuery.isPending ||
-    (isLibrarySessionKeyConnected(sessionKey()) && detailQuery.isPending);
+    !bootstrap.connected() || (isLibrarySessionKeyConnected(sessionKey()) && detailQuery.isPending);
   const statusTitle = () => {
     const current = detailResult();
     if (current && !Exit.isSuccess(current)) {

--- a/src/routes/_authenticated/library/search.tsx
+++ b/src/routes/_authenticated/library/search.tsx
@@ -1,23 +1,18 @@
 import { useAppScrollArea } from '@components/AppScrollAreaContext';
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import { LibrarySearchResultRow } from '@components/library/LibrarySearchResultRow';
 import { LibraryStatusPanel } from '@components/library/shared';
 import { Button } from '@components/ui';
 import { cx } from '@styled-system/css';
-import { createInfiniteQuery, createQuery, useQueryClient } from '@tanstack/solid-query';
+import { createInfiniteQuery, useQueryClient } from '@tanstack/solid-query';
 import { createFileRoute, redirect } from '@tanstack/solid-router';
 import { Exit } from 'effect';
 import { RefreshCw } from 'lucide-solid';
 import { For, Show, createEffect, createMemo, createSignal, onCleanup } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import { fetchVideoSearchPage } from '~effects/library';
 import type { LibraryExit, LibrarySearchState } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { queryKeys, runExit } from '~effects/query';
 import * as recipes from '~styles/recipes';
 
 import * as styles from './search.styles';
@@ -46,13 +41,9 @@ function LibrarySearchRoute() {
   const appScroll = useAppScrollArea();
   const [autoLoadSentinel, setAutoLoadSentinel] = createSignal<HTMLDivElement | null>(null);
   const [autoLoadSentinelVisible, setAutoLoadSentinelVisible] = createSignal(false);
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
-  const connected = () => isLibrarySessionKeyConnected(sessionKey());
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
+  const connected = bootstrap.connected;
 
   const searchQueryKey = () => queryKeys.librarySearch(sessionKey(), q());
   const searchQuery = createInfiniteQuery(() => ({

--- a/src/routes/_authenticated/library/shows/$seriesId.tsx
+++ b/src/routes/_authenticated/library/shows/$seriesId.tsx
@@ -4,6 +4,7 @@ import type {
   VideoSeason,
   VideoUserDataUpdateRequest,
 } from '@bindings';
+import { useAuthenticatedBootstrap } from '@components/AuthenticatedBootstrap';
 import {
   DetailHero,
   type DetailHeroInfoRow,
@@ -28,7 +29,6 @@ import { Exit, Option } from 'effect';
 import { Play, RefreshCw, Tv } from 'lucide-solid';
 import { For, Show, Suspense, createMemo, createSignal } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { fetchConnectionState } from '~effects/connection';
 import {
   fetchSeasonEpisodes,
   fetchVideoItemDetail,
@@ -38,12 +38,7 @@ import {
   updateLibraryUserData,
 } from '~effects/library';
 import type { LibraryExit, SeasonEpisodesState } from '~effects/library';
-import {
-  isLibrarySessionKeyConnected,
-  librarySessionKeyFromConnectionExit,
-  queryKeys,
-  runExit,
-} from '~effects/query';
+import { isLibrarySessionKeyConnected, queryKeys, runExit } from '~effects/query';
 
 import { AUTHENTICATED_HOME_ROUTE } from '../../../../router-guards';
 import * as styles from '../detailRoute.styles';
@@ -59,12 +54,8 @@ function LibraryShowDetailRoute() {
   const navigate = useNavigate();
   const canGoBack = useCanGoBack();
   const queryClient = useQueryClient();
-  const connectionQuery = createQuery(() => ({
-    queryKey: queryKeys.connectionState,
-    queryFn: () => runExit(fetchConnectionState),
-    staleTime: Infinity,
-  }));
-  const sessionKey = createMemo(() => librarySessionKeyFromConnectionExit(connectionQuery.data));
+  const bootstrap = useAuthenticatedBootstrap();
+  const sessionKey = bootstrap.sessionKey;
   const showQuery = createQuery(() => ({
     queryKey: queryKeys.libraryShowDetail(sessionKey(), params().seriesId),
     enabled: isLibrarySessionKeyConnected(sessionKey()),

--- a/tests/app-shell.test.tsx
+++ b/tests/app-shell.test.tsx
@@ -23,8 +23,9 @@ import type {
 } from '../src/bindings';
 import { itemThumb } from '../src/components/AppSidebar.styles';
 import { ToastProvider } from '../src/components/ToastProvider';
-import { queryKeys } from '../src/effects/query';
+import { librarySessionKey, queryKeys } from '../src/effects/query';
 import { createJellyPilotRouter } from '../src/router';
+import * as libraryStyles from '../src/routes/_authenticated/library.styles';
 import * as browseRouteStyles from '../src/routes/_authenticated/library/browseRoute.styles';
 import { resetSharedLibraryFilters } from '../src/utils/createSharedLibraryFilters';
 import { imageSource, resetImageProxyBase } from '../src/utils/imageSource';
@@ -1205,6 +1206,8 @@ test('library browse redirects home when active server changes under stale libra
   expect(screen.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(browseCommand).not.toHaveBeenCalled();
+  const previousSessionKey = librarySessionKey(connectedState);
+  expect(queryClient.getQueryData(queryKeys.libraryHome(previousSessionKey))).toBeUndefined();
 
   cleanup();
 });
@@ -2014,6 +2017,36 @@ test('library landing has no retry and skips video home when disconnected', asyn
   await screen.findByRole('navigation', { name: 'Sidebar' });
   expect(screen.queryByRole('button', { name: 'Retry Library' })).toBeNull();
   expect(videoHomeCommand).not.toHaveBeenCalled();
+
+  cleanup();
+});
+
+test('authenticated shell fetches connection identity once for all shell consumers', async () => {
+  mockShellCommands(disconnectedState);
+  const connectionStateCommand = rstest.spyOn(commands, 'serverGetState');
+  const cleanup = renderShell();
+
+  await screen.findByRole('navigation', { name: 'Sidebar' });
+  const settled = Promise.withResolvers<void>();
+  setTimeout(settled.resolve, 0);
+  await settled.promise;
+
+  expect(connectionStateCommand).toHaveBeenCalledTimes(1);
+
+  cleanup();
+});
+
+test('library landing stays empty without skeleton rows when disconnected', async () => {
+  mockShellCommands(disconnectedState);
+  const cleanup = renderShell();
+
+  await screen.findByRole('navigation', { name: 'Sidebar' });
+  const settled = Promise.withResolvers<void>();
+  setTimeout(settled.resolve, 0);
+  await settled.promise;
+
+  expect(screen.queryByRole('heading', { name: 'Continue Watching' })).toBeNull();
+  expect(document.querySelector(`.${libraryStyles.skeletonRow}`)).toBeNull();
 
   cleanup();
 });

--- a/tests/media-info.test.tsx
+++ b/tests/media-info.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'solid-js/web';
 
 import { commands } from '../src/bindings';
 import type { VideoItemDetail, VideoShowDetail } from '../src/bindings';
+import { AuthenticatedBootstrapProvider } from '../src/components/AuthenticatedBootstrap';
 import { MediaInfoContent, MediaInfoHoverCard } from '../src/components/library/MediaInfoHoverCard';
 import { fetchMediaDetail } from '../src/effects/library';
 import type { MediaDetail } from '../src/effects/library';
@@ -89,6 +90,7 @@ function mediaValue<A, E>(exit: Exit.Exit<A, E>): A | null {
 
 beforeEach(() => {
   rstest.spyOn(commands, 'serverGetState').mockResolvedValue(connectedState);
+  rstest.spyOn(commands, 'appLocalServices').mockResolvedValue({ imageProxyBase: null });
 });
 
 afterEach(() => {
@@ -191,9 +193,11 @@ test('MediaInfoHoverCard renders trigger children and does not fetch before open
   const dispose = render(
     () => (
       <TestQueryProvider>
-        <MediaInfoHoverCard id="movie-1" itemType="Movie">
-          <a href="/library/items/movie-1">Test Movie card</a>
-        </MediaInfoHoverCard>
+        <AuthenticatedBootstrapProvider>
+          <MediaInfoHoverCard id="movie-1" itemType="Movie">
+            <a href="/library/items/movie-1">Test Movie card</a>
+          </MediaInfoHoverCard>
+        </AuthenticatedBootstrapProvider>
       </TestQueryProvider>
     ),
     root,

--- a/tests/video-card.test.tsx
+++ b/tests/video-card.test.tsx
@@ -5,6 +5,8 @@ import { fireEvent, screen } from '@testing-library/dom';
 import type { JSX } from 'solid-js';
 import { render } from 'solid-js/web';
 
+import { commands } from '../src/bindings';
+import { AuthenticatedBootstrapProvider } from '../src/components/AuthenticatedBootstrap';
 import { HomeVideoCard } from '../src/components/library/HomeVideoCard';
 import { LibraryVideoCard } from '../src/components/library/LibraryVideoCard';
 import { PopupRoot } from '../src/components/ui/PopupRoot';
@@ -12,8 +14,29 @@ import { createJellyPilotRouter } from '../src/router';
 import { resetImageProxyBase, setImageProxyBase } from '../src/utils/imageSource';
 import { TestQueryProvider } from './query-client';
 
-beforeEach(() => setImageProxyBase('http://127.0.0.1:43127'));
+beforeEach(() => {
+  setImageProxyBase('http://127.0.0.1:43127');
+  rstest.spyOn(commands, 'serverGetState').mockResolvedValue({
+    capabilities: {
+      introSkipper: true,
+      quickConnect: true,
+      remoteControl: true,
+      remoteControlAvailable: true,
+      remoteControlWarning: null,
+    },
+    connected: true,
+    provider: 'jellyfin',
+    serverName: 'Jellyfin Home',
+    serverUrl: 'https://jellyfin.example.com',
+    userId: 'user-1',
+    userName: 'Ada',
+  });
+  rstest.spyOn(commands, 'appLocalServices').mockResolvedValue({
+    imageProxyBase: 'http://127.0.0.1:43127',
+  });
+});
 afterEach(() => {
+  rstest.restoreAllMocks();
   resetImageProxyBase();
   document.body.innerHTML = '';
 });
@@ -26,7 +49,9 @@ function renderWithRouter(content: () => JSX.Element) {
     () => (
       <TestQueryProvider>
         <PopupRoot>
-          <RouterContextProvider router={router}>{content}</RouterContextProvider>
+          <RouterContextProvider router={router}>
+            {() => <AuthenticatedBootstrapProvider>{content()}</AuthenticatedBootstrapProvider>}
+          </RouterContextProvider>
         </PopupRoot>
       </TestQueryProvider>
     ),


### PR DESCRIPTION
One AuthenticatedBootstrap provider mounts the single connection-state
observer for the authenticated shell and supplies session identity to
the Sidebar, Video Home, and Library Browser through context instead of
per-component observers. Video Home renders only for a connected
session key and stays empty (no skeleton rows) when disconnected or
failed. Saved Service Profile switches replace the session identity,
clear session-scoped Library Browser data, and return affected routes
to the authenticated home. Application-local services are requested
once per shell mount; Library Image sources stay empty until the image
proxy reports readiness and update in place when it does.

Closes #203

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>