### PR TITLE
feat(now-playing): emit from transport snapshot without resampling MPV properties

### DIFF
--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -359,6 +359,9 @@ pub async fn mpv_start(
   jellyfin_state: State<'_, JellyfinState>,
 ) -> Result<(), CommandError> {
   state.0.start().await.map_err(internal_err)?;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| transport.mark_connected());
+  }
   playback_control::emit_now_playing_changed(&app, &jellyfin_state).await;
   Ok(())
 }
@@ -372,6 +375,9 @@ pub async fn mpv_stop(
   jellyfin_state: State<'_, JellyfinState>,
 ) -> Result<(), CommandError> {
   state.0.stop().await;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| transport.clear());
+  }
   playback_control::emit_now_playing_changed(&app, &jellyfin_state).await;
   Ok(())
 }
@@ -402,6 +408,11 @@ pub async fn mpv_seek(
     return Err(CommandError::invalid_input("Seek time cannot be negative"));
   }
   state.0.seek(time).await.map_err(internal_err)?;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| {
+      transport.apply_property("time-pos", &serde_json::json!(time));
+    });
+  }
   playback_control::emit_now_playing_changed(&app, &jellyfin_state).await;
   Ok(())
 }
@@ -433,6 +444,11 @@ pub async fn mpv_set_volume(
     ));
   }
   state.0.set_volume(volume).await.map_err(internal_err)?;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| {
+      transport.apply_property("volume", &serde_json::json!(volume));
+    });
+  }
   playback_control::emit_now_playing_changed(&app, &jellyfin_state).await;
   Ok(())
 }

--- a/src-tauri/src/jellyfin/session.rs
+++ b/src-tauri/src/jellyfin/session.rs
@@ -21,13 +21,11 @@ use super::play_resolution::{
 };
 use super::types::*;
 use super::websocket::{JellyfinCommand, JellyfinWebSocket, JellyfinWebSocketEvent};
-use crate::command::{AppNotification, NowPlayingChanged};
+use crate::command::{AppNotification, NowPlayingChanged, NowPlayingState};
 use crate::config::{AppConfig, IntroSkipperMode};
 use crate::hls_proxy::{ActivatedHls, HlsProxyError, HlsProxyEvent, HlsProxyState};
 use crate::mpv::{has_mpv_option, MpvClient};
-use crate::now_playing::{
-  build_now_playing_state, collect_player_state, PlaybackContext, TransportSnapshot,
-};
+use crate::now_playing::{build_now_playing_state, PlaybackContext, TransportSnapshot};
 use tauri_specta::Event;
 
 const PREFERENCES_STORE_FILE: &str = "preferences.json";
@@ -234,26 +232,48 @@ impl SessionManager {
     self.state.read().current_item.clone()
   }
 
-  async fn emit_now_playing_changed(
-    app_handle: &AppHandle,
-    mpv: &MpvClient,
-    state: &RwLock<SessionState>,
-  ) {
-    let player = collect_player_state(mpv).await;
-    let state = state.read();
-    let now_playing = build_now_playing_state(
+  /// Project the current Now Playing state from the maintained transport
+  /// snapshot. This is the single projection owner for every emission path;
+  /// it never issues MPV property queries.
+  fn project_now_playing(state: &RwLock<SessionState>) -> NowPlayingState {
+    let s = state.read();
+    let media_runtime_seconds = s
+      .current_item
+      .as_ref()
+      .and_then(|item| item.run_time_ticks)
+      .map(ticks_to_seconds);
+    let player = s.transport.project(media_runtime_seconds);
+    build_now_playing_state(
       player,
       PlaybackContext {
-        has_active_session: true,
-        current_item: state.current_item.as_ref(),
+        has_active_session: s.playback.is_some(),
+        current_item: s.current_item.as_ref(),
       },
-    );
+    )
+  }
 
-    let event = NowPlayingChanged { state: now_playing };
+  /// Shared emission owner for Now Playing changes: projects from the
+  /// transport snapshot and emits without resampling MPV properties.
+  async fn emit_now_playing_changed(app_handle: &AppHandle, state: &RwLock<SessionState>) {
+    let event = NowPlayingChanged {
+      state: Self::project_now_playing(state),
+    };
 
     if let Err(e) = event.emit(app_handle) {
       log::error!("Failed to emit Now Playing state: {}", e);
     }
+  }
+
+  /// Command/tray entry point into the shared emission owner.
+  pub async fn emit_now_playing_snapshot(&self) {
+    Self::emit_now_playing_changed(&self.app_handle, &self.state).await;
+  }
+
+  /// Record a command-driven transport mutation so command-path emission
+  /// reflects it before the corresponding MPV observation lands.
+  pub fn seed_transport(&self, update: impl FnOnce(&mut TransportSnapshot)) {
+    let mut s = self.state.write();
+    update(&mut s.transport);
   }
 
   /// Load series preferences from disk.
@@ -1058,6 +1078,10 @@ impl SessionManager {
       s.current_series_id = item.series_id.clone();
       s.current_item = Some(item.clone());
       s.current_media_streams = media_source.media_streams.clone();
+      // Re-seed Now Playing transport for the new session so stale per-item
+      // state never leaks across sessions; observations reconcile the rest.
+      s.transport
+        .reset_for_new_session(ticks_to_seconds(resolution.position_ticks));
       s.playback = Some(PlaybackSession {
         item_id: item_id.clone(),
         media_source_id: Some(media_source.id.clone()),
@@ -1628,16 +1652,16 @@ impl SessionManager {
 
               if should_report {
                 Self::report_progress(&client, &state).await;
-                Self::emit_now_playing_changed(&app_handle, &mpv, &state).await;
+                Self::emit_now_playing_changed(&app_handle, &state).await;
               }
             }
             "end-file" => {
               Self::handle_end_file_event(&event, &ctx).await;
-              Self::emit_now_playing_changed(&app_handle, &mpv, &state).await;
+              Self::emit_now_playing_changed(&app_handle, &state).await;
             }
             "client-message" => {
               Self::handle_client_message_event(&event, &ctx).await;
-              Self::emit_now_playing_changed(&app_handle, &mpv, &state).await;
+              Self::emit_now_playing_changed(&app_handle, &state).await;
             }
             "seek" => {
               // A seek invalidates every prefetched lookahead window
@@ -1663,7 +1687,7 @@ impl SessionManager {
         // Clear playback context and notify Jellyfin
         log::warn!("MPV event receiver closed, clearing playback context...");
         Self::clear_playback_context(&client, &state, &hls).await;
-        Self::emit_now_playing_changed(&app_handle, &mpv, &state).await;
+        Self::emit_now_playing_changed(&app_handle, &state).await;
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
       }
     });
@@ -1921,8 +1945,6 @@ impl SessionManager {
   ) {
     let session = {
       let mut s = state.write();
-      // Playback is idle until a new session starts; drop stale transport state.
-      s.transport.clear();
       s.playback.take()
     };
 
@@ -4032,5 +4054,164 @@ mod regression_tests {
     // Negative string Index (subtitle disable)
     let args = serde_json::json!({"Index": "-1"});
     assert_eq!(parse_command_int(args.get("Index")), Some(-1));
+  }
+
+  fn transport_observation(name: &str, data: serde_json::Value) -> crate::mpv::MpvEvent {
+    crate::mpv::MpvEvent {
+      event: "property-change".to_string(),
+      id: Some(1),
+      name: Some(name.to_string()),
+      data: Some(data),
+      reason: None,
+      args: None,
+    }
+  }
+
+  fn test_state_with_episode_playback() -> RwLock<SessionState> {
+    RwLock::new(SessionState {
+      playback: Some(PlaybackSession {
+        item_id: "episode-1".to_string(),
+        media_source_id: Some("source-1".to_string()),
+        play_session_id: Some("play-1".to_string()),
+        intro_skipper_ranges: Vec::new(),
+        position_ticks: seconds_to_ticks(42.5),
+        is_paused: true,
+        is_muted: true,
+        volume: 64,
+        audio_stream_index: None,
+        subtitle_stream_index: None,
+        play_method: "DirectPlay".to_string(),
+        hls_proxy_session_id: None,
+        hls_recovery_attempted: false,
+        hls_recovering: false,
+      }),
+      transport: TransportSnapshot::default(),
+      last_report_time: std::time::Instant::now(),
+      effective_intro_skipper_config: IntroSkipperRuntimeConfig::from(&AppConfig::default()),
+      current_series_id: Some("series-1".to_string()),
+      current_item: Some(MediaItem {
+        id: "episode-1".to_string(),
+        name: "The Pilot".to_string(),
+        item_type: "Episode".to_string(),
+        series_id: Some("series-1".to_string()),
+        series_name: Some("Example Show".to_string()),
+        season_name: Some("Season 1".to_string()),
+        index_number: Some(1),
+        parent_index_number: Some(1),
+        run_time_ticks: Some(15_000_000_000),
+        overview: None,
+      }),
+      current_media_streams: Vec::new(),
+      series_preferences: HashMap::new(),
+      recorded_notifications: Vec::new(),
+    })
+  }
+
+  #[tokio::test]
+  async fn snapshot_projection_emits_full_state_without_mpv_property_queries() {
+    use crate::command::NowPlayingStatus;
+    use crate::mpv::MpvIpc;
+    use crate::now_playing::collect_player_state;
+    use tokio::io::{duplex, AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    // MPV test seam: in-memory duplex IPC with a recording peer that answers
+    // every command so property queries would succeed if any were issued.
+    let mpv = MpvClient::new(None);
+    let (client_stream, peer_stream) = duplex(64 * 1024);
+    let (reader, writer) = tokio::io::split(client_stream);
+    let ipc = MpvIpc::from_io_for_test(reader, writer)
+      .await
+      .expect("test IPC should be constructed");
+    mpv.install_ipc_for_test(ipc);
+
+    let wire_log = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let peer_log = Arc::clone(&wire_log);
+    let (peer_reader, mut peer_writer) = tokio::io::split(peer_stream);
+    let peer = tokio::spawn(async move {
+      let mut lines = BufReader::new(peer_reader).lines();
+      while let Ok(Some(line)) = lines.next_line().await {
+        peer_log.lock().expect("wire log").push(line.clone());
+        let request_id = serde_json::from_str::<serde_json::Value>(&line)
+          .ok()
+          .and_then(|value| value.get("request_id").and_then(|id| id.as_i64()));
+        if let Some(request_id) = request_id {
+          let _ = peer_writer
+            .write_all(
+              format!(
+                r#"{{"request_id":{},"error":"success","data":null}}"#,
+                request_id
+              )
+              .as_bytes(),
+            )
+            .await;
+          let _ = peer_writer.write_all(b"\n").await;
+        }
+      }
+    });
+
+    // Vacuity check: the legacy live collection fans out five property
+    // queries, proving the recording peer would observe any query.
+    let _ = collect_player_state(&mpv).await;
+    let live_queries = wire_log
+      .lock()
+      .expect("wire log")
+      .iter()
+      .filter(|line| line.contains("get_property"))
+      .count();
+    assert_eq!(live_queries, 5);
+    wire_log.lock().expect("wire log").clear();
+
+    // Hot path: MPV observations feed the snapshot, then emission projects it.
+    let state = test_state_with_episode_playback();
+    for (name, data) in [
+      ("pause", serde_json::json!(true)),
+      ("volume", serde_json::json!(64.0)),
+      ("mute", serde_json::json!(true)),
+      ("time-pos", serde_json::json!(42.5)),
+      ("duration", serde_json::json!(1420.0)),
+    ] {
+      SessionManager::update_transport_from_property(&state, &transport_observation(name, data));
+    }
+
+    let projected = SessionManager::project_now_playing(&state);
+
+    let hot_queries = wire_log
+      .lock()
+      .expect("wire log")
+      .iter()
+      .filter(|line| line.contains("get_property"))
+      .count();
+    assert_eq!(hot_queries, 0);
+
+    assert!(matches!(projected.status, NowPlayingStatus::Paused));
+    assert!(projected.player.connected);
+    assert!(projected.player.paused);
+    assert!(projected.player.muted);
+    assert_eq!(projected.player.volume, 64.0);
+    assert_eq!(projected.player.time_pos, 42.5);
+    assert_eq!(projected.player.duration, 1420.0);
+    let media = projected.media.expect("episode media");
+    assert_eq!(media.item_id, "episode-1");
+    assert_eq!(media.name, "The Pilot");
+    assert!(projected.can_play_next);
+    assert!(projected.can_play_previous);
+
+    // Missing observed duration falls back to the current media runtime,
+    // still without property queries.
+    SessionManager::update_transport_from_property(
+      &state,
+      &transport_observation("duration", serde_json::json!(null)),
+    );
+    let fallback = SessionManager::project_now_playing(&state);
+    assert_eq!(fallback.player.duration, 1500.0);
+    let fallback_queries = wire_log
+      .lock()
+      .expect("wire log")
+      .iter()
+      .filter(|line| line.contains("get_property"))
+      .count();
+    assert_eq!(fallback_queries, 0);
+
+    peer.abort();
   }
 }

--- a/src-tauri/src/mpv/client.rs
+++ b/src-tauri/src/mpv/client.rs
@@ -434,6 +434,12 @@ impl MpvClient {
     let guard = self.ipc.lock();
     guard.as_ref().map(|ipc| ipc.events())
   }
+
+  /// Install an already-established IPC connection (MPV test seam).
+  #[cfg(test)]
+  pub(crate) fn install_ipc_for_test(&self, ipc: MpvIpc) {
+    *self.ipc.lock() = Some(Arc::new(ipc));
+  }
 }
 
 // Need to implement Clone manually because Child doesn't implement Clone

--- a/src-tauri/src/mpv/ipc.rs
+++ b/src-tauri/src/mpv/ipc.rs
@@ -148,7 +148,7 @@ impl MpvIpc {
   }
 
   #[cfg(test)]
-  pub(super) async fn from_io_for_test<R, W>(reader: R, writer: W) -> Result<Self, IpcError>
+  pub(crate) async fn from_io_for_test<R, W>(reader: R, writer: W) -> Result<Self, IpcError>
   where
     R: tokio::io::AsyncRead + Send + Unpin + 'static,
     W: tokio::io::AsyncWrite + Send + Unpin + 'static,

--- a/src-tauri/src/mpv/mod.rs
+++ b/src-tauri/src/mpv/mod.rs
@@ -13,5 +13,7 @@ mod protocol;
 
 pub(crate) use client::has_mpv_option;
 pub use client::MpvClient;
+#[cfg(test)]
+pub(crate) use ipc::MpvIpc;
 pub use process::{find_mpv, write_input_conf};
 pub use protocol::{MpvEvent, PropertyValue};

--- a/src-tauri/src/now_playing.rs
+++ b/src-tauri/src/now_playing.rs
@@ -75,10 +75,38 @@ impl TransportSnapshot {
     *self = Self::default();
   }
 
+  /// Mark transport connected when a command path starts the MPV process
+  /// before any property observation has landed.
+  pub fn mark_connected(&mut self) {
+    self.connected = true;
+  }
+
+  /// Current muted state, for command paths that toggle mute and need the
+  /// resulting value before the observation lands.
+  pub fn muted(&self) -> bool {
+    self.muted
+  }
+
+  /// Re-seed transport for a newly started playback session: per-item
+  /// position/duration reset while process-level volume and mute persist.
+  pub fn reset_for_new_session(&mut self, start_position_seconds: f64) {
+    *self = Self {
+      connected: true,
+      paused: false,
+      muted: self.muted,
+      time_pos: if start_position_seconds.is_finite() {
+        start_position_seconds.max(0.0)
+      } else {
+        0.0
+      },
+      volume: self.volume,
+      observed_duration: None,
+    };
+  }
+
   /// Project the snapshot into the Now Playing player state. Duration falls
   /// back to the current media runtime, then zero, so the projection always
   /// carries a finite non-negative duration.
-  #[allow(dead_code)] // Consumed by snapshot-based Now Playing emission (#205).
   pub fn project(&self, media_runtime_seconds: Option<f64>) -> PlayerState {
     let duration = self
       .observed_duration
@@ -463,5 +491,47 @@ mod tests {
     assert_eq!(player.time_pos, 0.0);
     assert_eq!(player.volume, 0.0);
     assert_eq!(player.duration, 1500.0);
+  }
+
+  #[test]
+  fn new_session_reseed_preserves_volume_and_mute() {
+    let mut snapshot = observed(&[
+      ("pause", serde_json::json!(true)),
+      ("volume", serde_json::json!(64.0)),
+      ("mute", serde_json::json!(true)),
+      ("time-pos", serde_json::json!(42.5)),
+      ("duration", serde_json::json!(1420.0)),
+    ]);
+
+    snapshot.reset_for_new_session(120.0);
+    let player = snapshot.project(Some(1500.0));
+
+    assert!(player.connected);
+    assert!(!player.paused);
+    assert!(player.muted);
+    assert_eq!(player.time_pos, 120.0);
+    assert_eq!(player.volume, 64.0);
+    assert_eq!(player.duration, 1500.0);
+  }
+
+  #[test]
+  fn new_session_reseed_sanitizes_invalid_start_position() {
+    let mut snapshot = observed(&[("pause", serde_json::json!(true))]);
+
+    snapshot.reset_for_new_session(f64::NAN);
+    assert_eq!(snapshot.project(None).time_pos, 0.0);
+
+    snapshot.reset_for_new_session(-5.0);
+    assert_eq!(snapshot.project(None).time_pos, 0.0);
+  }
+
+  #[test]
+  fn mark_connected_projects_idle_connected_transport() {
+    let mut snapshot = TransportSnapshot::default();
+    snapshot.mark_connected();
+    let player = snapshot.project(None);
+
+    assert!(player.connected);
+    assert_eq!(player.duration, 0.0);
   }
 }

--- a/src-tauri/src/playback_control.rs
+++ b/src-tauri/src/playback_control.rs
@@ -36,11 +36,20 @@ pub async fn collect_now_playing_state(state: &JellyfinState) -> NowPlayingState
 }
 
 pub async fn emit_now_playing_changed(app: &tauri::AppHandle, state: &JellyfinState) {
-  let event = NowPlayingChanged {
-    state: collect_now_playing_state(state).await,
-  };
-  if let Err(e) = event.emit(app) {
-    log::error!("Failed to emit now playing state: {}", e);
+  let session = state.session.read().clone();
+  match session {
+    // Every session-backed path emits through the shared snapshot owner.
+    Some(session) => session.emit_now_playing_snapshot().await,
+    // Without a session there is no snapshot owner; keep the cold
+    // live-collection reconciliation for the disconnected projection.
+    None => {
+      let event = NowPlayingChanged {
+        state: collect_now_playing_state(state).await,
+      };
+      if let Err(e) = event.emit(app) {
+        log::error!("Failed to emit now playing state: {}", e);
+      }
+    }
   }
 }
 
@@ -54,6 +63,11 @@ pub async fn set_pause(
     .set_pause(paused)
     .await
     .map_err(|e| CommandError::internal(e.to_string()))?;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| {
+      transport.apply_property("pause", &serde_json::json!(paused));
+    });
+  }
   emit_now_playing_changed(app, jellyfin_state).await;
   Ok(())
 }
@@ -79,6 +93,12 @@ pub async fn toggle_mute(
     .toggle_mute()
     .await
     .map_err(|e| CommandError::internal(e.to_string()))?;
+  if let Some(session) = jellyfin_state.session.read().clone() {
+    session.seed_transport(|transport| {
+      let muted = !transport.muted();
+      transport.apply_property("mute", &serde_json::json!(muted));
+    });
+  }
   emit_now_playing_changed(app, jellyfin_state).await;
   Ok(())
 }


### PR DESCRIPTION
Route every Now Playing emission through one shared projection/emission
owner fed by the maintained transport snapshot. A reportable MPV event
now emits full state without issuing pause, position, duration, volume,
or mute property queries; command and tray paths delegate to the same
owner and seed command-driven mutations so emitted state reflects them
before observations land. New playback sessions re-seed transport,
preserving process-level volume and mute while clearing per-item
position and duration. The pull command keeps its live collection for
cold-start and disconnected reconciliation, the parallel private
SessionManager builder is gone, and command/event names and payloads are
unchanged. A backend test over the duplex MPV test seam proves zero
property-query fan-out on the hot emit path and correct emitted state,
including the media-runtime duration fallback.

Closes #205

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>