### PR TITLE
feat(now-playing): own the Now Playing subscription at the shell

### DIFF
--- a/src/components/NowPlayingCard.tsx
+++ b/src/components/NowPlayingCard.tsx
@@ -21,7 +21,6 @@ import * as recipes from '~styles/recipes';
 import type { NowPlayingState } from '../bindings';
 import { commandFailureMessage } from '../effects/commands';
 import {
-  createNowPlayingState,
   fetchMpvTrackList,
   setAudioTrack,
   setSubtitleTrack,
@@ -37,6 +36,7 @@ import {
 import type { NowPlayingEffect } from '../effects/nowPlaying';
 import { queryKeys, runExit } from '../effects/query';
 import * as styles from './NowPlayingCard.styles';
+import { useNowPlaying } from './NowPlayingProvider';
 import { useToast } from './ToastProvider';
 import { Button, JellyPilotSelect, StatusBadge } from './ui';
 
@@ -131,15 +131,15 @@ export default function NowPlayingCard(props: {
   const [busy, setBusy] = createSignal<string | null>(null);
   const [seekDraft, setSeekDraft] = createSignal<number | null>(null);
   const [volumeDraft, setVolumeDraft] = createSignal<number | null>(null);
-  const { query: nowPlayingQuery, state: current } = createNowPlayingState({
-    onExternalChange: (state) => {
-      setSeekDraft(null);
-      setVolumeDraft(null);
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.mpvTracks(state.player.connected),
-      });
-    },
+  const nowPlaying = useNowPlaying();
+  nowPlaying.onExternalChange((state) => {
+    setSeekDraft(null);
+    setVolumeDraft(null);
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.mpvTracks(state.player.connected),
+    });
   });
+  const current = nowPlaying.state;
   const player = () => current()?.player;
   const connected = () => player()?.connected ?? false;
   const status = () => current()?.status ?? 'unknown';
@@ -161,7 +161,7 @@ export default function NowPlayingCard(props: {
     setBusy(key);
     const exit = await playerCommandMutation.mutateAsync(command);
     if (Exit.isSuccess(exit)) {
-      await nowPlayingQuery.refetch();
+      await nowPlaying.refresh();
       await tracksQuery.refetch();
     } else {
       showToast('error', commandFailureMessage(exit.cause, failure));

--- a/src/components/NowPlayingDrawer.tsx
+++ b/src/components/NowPlayingDrawer.tsx
@@ -6,9 +6,9 @@ import { Portal } from 'solid-js/web';
 import * as recipes from '~styles/recipes';
 
 import type { NowPlayingState } from '../bindings';
-import { createNowPlayingState } from '../effects/nowPlaying';
 import NowPlayingCard from './NowPlayingCard';
 import * as styles from './NowPlayingDrawer.styles';
+import { useNowPlaying } from './NowPlayingProvider';
 import { Button } from './ui';
 
 const statusText = Match.type<NowPlayingState['status'] | undefined>().pipe(
@@ -42,7 +42,7 @@ export default function NowPlayingDrawer(props: {
   jellyfinConnected: boolean;
   collapsed: boolean;
 }) {
-  const { state } = createNowPlayingState();
+  const { state } = useNowPlaying();
   const [open, setOpen] = createSignal(false);
   const [selectPortalMount, setSelectPortalMount] = createSignal<HTMLElement>();
 

--- a/src/components/NowPlayingProvider.tsx
+++ b/src/components/NowPlayingProvider.tsx
@@ -1,0 +1,78 @@
+import { createQuery, useQueryClient } from '@tanstack/solid-query';
+import { Exit } from 'effect';
+import { type JSX, createContext, onCleanup, onMount, useContext } from 'solid-js';
+import { fetchNowPlayingState, listenNowPlayingChanged } from '~effects/nowPlaying';
+import { queryKeys, runExit } from '~effects/query';
+
+import type { NowPlayingState } from '../bindings';
+
+/**
+ * Shell-level Now Playing owner: the single query observer and Tauri change
+ * listener for the authenticated shell. The Sidebar trigger and the Now
+ * Playing controls consume this context so pushed state can never diverge
+ * between them, and the listener is disposed exactly once with the shell.
+ */
+export interface NowPlayingOwner {
+  readonly state: () => NowPlayingState | null;
+  /** Refetch the shared Now Playing query entry after a successful command. */
+  readonly refresh: () => Promise<unknown>;
+  /**
+   * Register a consumer callback for pushed Now Playing changes (e.g. to
+   * clear local drafts or invalidate dependent queries). Registration is
+   * cleaned up with the calling consumer's Solid owner.
+   */
+  readonly onExternalChange: (callback: (state: NowPlayingState) => void) => void;
+}
+
+const NowPlayingContext = createContext<NowPlayingOwner>();
+
+export function useNowPlaying(): NowPlayingOwner {
+  const context = useContext(NowPlayingContext);
+  if (!context) {
+    throw new Error('useNowPlaying must be used within NowPlayingProvider');
+  }
+  return context;
+}
+
+export function NowPlayingProvider(props: { children: JSX.Element }) {
+  const queryClient = useQueryClient();
+  const query = createQuery(() => ({
+    queryKey: queryKeys.nowPlayingState,
+    queryFn: () => runExit(fetchNowPlayingState),
+  }));
+  const externalChangeListeners = new Set<(state: NowPlayingState) => void>();
+
+  onMount(() => {
+    let disposed = false;
+    let cleanup: (() => void) | undefined;
+    listenNowPlayingChanged((state) => {
+      queryClient.setQueryData(queryKeys.nowPlayingState, Exit.succeed(state));
+      for (const listener of externalChangeListeners) {
+        listener(state);
+      }
+    }).then((unlisten) => {
+      if (disposed) {
+        unlisten();
+      } else {
+        cleanup = unlisten;
+      }
+    });
+
+    onCleanup(() => {
+      disposed = true;
+      cleanup?.();
+    });
+  });
+
+  const state = () => (query.data && Exit.isSuccess(query.data) ? query.data.value : null);
+  const refresh = () => query.refetch();
+  const onExternalChange = (callback: (state: NowPlayingState) => void) => {
+    externalChangeListeners.add(callback);
+    onCleanup(() => {
+      externalChangeListeners.delete(callback);
+    });
+  };
+
+  const value: NowPlayingOwner = { state, refresh, onExternalChange };
+  return <NowPlayingContext.Provider value={value}>{props.children}</NowPlayingContext.Provider>;
+}

--- a/src/effects/nowPlaying.ts
+++ b/src/effects/nowPlaying.ts
@@ -1,12 +1,9 @@
 import { commands, events } from '@bindings';
 import type { NowPlayingState, PropertyValue } from '@bindings';
-import { createQuery, useQueryClient } from '@tanstack/solid-query';
 import { Effect, Exit, Option } from 'effect';
-import { onCleanup, onMount } from 'solid-js';
 
 import { runTauriCommand } from './commands';
 import type { CommandError } from './errors';
-import { queryKeys, runExit } from './query';
 
 export type NowPlayingEffect<T> = Effect.Effect<T, CommandError>;
 
@@ -121,43 +118,4 @@ export function listenNowPlayingChanged(
   onState: (state: NowPlayingState) => void,
 ): Promise<() => void> {
   return events.nowPlayingChanged.listen((event) => onState(event.payload.state));
-}
-
-/**
- * Shared Now Playing state source: one query cache entry plus the Tauri change
- * listener that keeps it fresh. Consumers read `state()`; `onExternalChange`
- * lets owners clear local drafts or invalidate dependent queries on push.
- */
-export function createNowPlayingState(options?: {
-  onExternalChange?: (state: NowPlayingState) => void;
-}) {
-  const queryClient = useQueryClient();
-  const query = createQuery(() => ({
-    queryKey: queryKeys.nowPlayingState,
-    queryFn: () => runExit(fetchNowPlayingState),
-  }));
-
-  onMount(() => {
-    let disposed = false;
-    let cleanup: (() => void) | undefined;
-    listenNowPlayingChanged((state) => {
-      queryClient.setQueryData(queryKeys.nowPlayingState, Exit.succeed(state));
-      options?.onExternalChange?.(state);
-    }).then((unlisten) => {
-      if (disposed) {
-        unlisten();
-      } else {
-        cleanup = unlisten;
-      }
-    });
-
-    onCleanup(() => {
-      disposed = true;
-      cleanup?.();
-    });
-  });
-
-  const state = () => (query.data && Exit.isSuccess(query.data) ? query.data.value : null);
-
-  return { query, state };
 }

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -8,6 +8,7 @@ import {
   AuthenticatedBootstrapProvider,
   useAuthenticatedBootstrap,
 } from '../components/AuthenticatedBootstrap';
+import { NowPlayingProvider } from '../components/NowPlayingProvider';
 import { AUTHENTICATED_HOME_ROUTE, requireAuthenticatedShell } from '../router-guards';
 import * as styles from './_authenticated.styles';
 
@@ -22,7 +23,9 @@ function AuthenticatedShell() {
     <AuthenticatedBootstrapProvider
       onSessionChange={() => void navigate({ to: AUTHENTICATED_HOME_ROUTE, replace: true })}
     >
-      <AuthenticatedShellContent />
+      <NowPlayingProvider>
+        <AuthenticatedShellContent />
+      </NowPlayingProvider>
     </AuthenticatedBootstrapProvider>
   );
 }

--- a/tests/app-shell.test.tsx
+++ b/tests/app-shell.test.tsx
@@ -2126,6 +2126,61 @@ test('now playing drawer exposes full playback controls', async () => {
   cleanup();
 });
 
+test('now playing trigger and controls share one change listener across drawer reopen', async () => {
+  mockShellCommands();
+  const unlisten = rstest.fn();
+  const listen = rstest.spyOn(events.nowPlayingChanged, 'listen').mockResolvedValue(unlisten);
+  const cleanup = renderShell();
+
+  const trigger = await screen.findByRole('button', { name: /Now Playing: Playing — The Pilot/ });
+  expect(listen).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(trigger);
+  await screen.findByRole('dialog', { name: 'Now Playing' });
+  expect(listen).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Close Now Playing' }));
+  await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Now Playing' })).toBeNull());
+
+  fireEvent.click(await screen.findByRole('button', { name: /Now Playing: Playing — The Pilot/ }));
+  await screen.findByRole('dialog', { name: 'Now Playing' });
+
+  expect(listen).toHaveBeenCalledTimes(1);
+  expect(unlisten).not.toHaveBeenCalled();
+
+  cleanup();
+});
+
+test('now playing trigger and controls update from the same pushed state', async () => {
+  mockShellCommands();
+  let pushState: ((state: NowPlayingState) => void) | null = null;
+  rstest.spyOn(events.nowPlayingChanged, 'listen').mockImplementation((handler) => {
+    pushState = (state) => handler({ event: 'now-playing-changed', id: 0, payload: { state } });
+    return Promise.resolve(() => {});
+  });
+  const cleanup = renderShell();
+
+  const trigger = await screen.findByRole('button', { name: /Now Playing: Playing — The Pilot/ });
+  fireEvent.click(trigger);
+  await screen.findByRole('dialog', { name: 'Now Playing' });
+
+  const pausedState: NowPlayingState = {
+    ...nowPlaying,
+    player: { ...nowPlaying.player, paused: true },
+    status: 'paused',
+  };
+  pushState?.(pausedState);
+
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Now Playing: Paused — The Pilot' })).toBeVisible(),
+  );
+  const dialog = screen.getByRole('dialog', { name: 'Now Playing' });
+  expect(within(dialog).getByText('Paused')).toBeVisible();
+  expect(within(dialog).getByRole('button', { name: 'Play' })).toBeVisible();
+
+  cleanup();
+});
+
 test('Settings modal opens operations console content and closes via Close button and Escape', async () => {
   mockShellCommands();
   localStorage.setItem(

--- a/tests/now-playing-card.test.tsx
+++ b/tests/now-playing-card.test.tsx
@@ -6,6 +6,7 @@ import { render } from 'solid-js/web';
 import { commands, events } from '../src/bindings';
 import type { NowPlayingState } from '../src/bindings';
 import NowPlayingCard from '../src/components/NowPlayingCard';
+import { NowPlayingProvider } from '../src/components/NowPlayingProvider';
 import { ToastProvider } from '../src/components/ToastProvider';
 import { TestQueryProvider } from './query-client';
 
@@ -100,7 +101,9 @@ function renderCard(state: NowPlayingState = offlineState, jellyfinConnected = t
     () => (
       <TestQueryProvider>
         <ToastProvider>
-          <NowPlayingCard jellyfinConnected={jellyfinConnected} />
+          <NowPlayingProvider>
+            <NowPlayingCard jellyfinConnected={jellyfinConnected} />
+          </NowPlayingProvider>
         </ToastProvider>
       </TestQueryProvider>
     ),
@@ -298,7 +301,9 @@ test('clicking mute toggles icon and label after state reloads', async () => {
     () => (
       <TestQueryProvider>
         <ToastProvider>
-          <NowPlayingCard jellyfinConnected />
+          <NowPlayingProvider>
+            <NowPlayingCard jellyfinConnected />
+          </NowPlayingProvider>
         </ToastProvider>
       </TestQueryProvider>
     ),
@@ -313,6 +318,67 @@ test('clicking mute toggles icon and label after state reloads', async () => {
 
   await waitFor(() => expect(toggleMute).toHaveBeenCalled());
   await waitFor(() => expect(screen.getByRole('button', { name: 'Unmute' })).toBeVisible());
+
+  dispose();
+  root.remove();
+});
+
+test('pushed change clears seek and volume drafts and invalidates track data', async () => {
+  rstest.spyOn(commands, 'nowPlayingGetState').mockResolvedValue({
+    data: playingState,
+    status: 'ok',
+  });
+  const getProperty = rstest
+    .spyOn(commands, 'mpvGetProperty')
+    .mockResolvedValue({ data: trackList, status: 'ok' });
+  rstest.spyOn(commands, 'mpvSeek').mockResolvedValue({ data: null, status: 'ok' });
+  rstest.spyOn(commands, 'mpvSetVolume').mockResolvedValue({ data: null, status: 'ok' });
+  let pushState: ((state: NowPlayingState) => void) | null = null;
+  rstest.spyOn(events.nowPlayingChanged, 'listen').mockImplementation((handler) => {
+    pushState = (state) => handler({ event: 'now-playing-changed', id: 0, payload: { state } });
+    return Promise.resolve(() => {});
+  });
+  const root = document.createElement('div');
+  document.body.append(root);
+  const dispose = render(
+    () => (
+      <TestQueryProvider>
+        <ToastProvider>
+          <NowPlayingProvider>
+            <NowPlayingCard jellyfinConnected />
+          </NowPlayingProvider>
+        </ToastProvider>
+      </TestQueryProvider>
+    ),
+    root,
+  );
+
+  const seekSlider = await screen.findByRole('slider', { name: 'Seek position' });
+  await waitFor(() => expect(seekSlider).toHaveAttribute('aria-valuenow', '30'));
+  const volumeSlider = screen.getByRole('slider', { name: 'Volume' });
+  await waitFor(() => expect(volumeSlider).toHaveAttribute('aria-valuenow', '80'));
+
+  seekSlider.focus();
+  fireEvent.keyDown(seekSlider, { key: 'ArrowRight' });
+  await waitFor(() => expect(seekSlider).toHaveAttribute('aria-valuenow', '31'));
+  await waitFor(() => expect(rstest.mocked(commands.mpvSeek)).toHaveBeenCalledWith(31));
+  const volumeThumb = screen.getByRole('slider', { name: 'Volume' });
+  await waitFor(() => expect(volumeThumb).not.toHaveAttribute('data-disabled'));
+  volumeThumb.focus();
+  fireEvent.keyDown(volumeThumb, { key: 'ArrowLeft' });
+  await waitFor(() => expect(volumeThumb).toHaveAttribute('aria-valuenow', '79'));
+
+  const trackFetchesBeforePush = getProperty.mock.calls.length;
+  pushState?.({
+    ...playingState,
+    player: { ...playingState.player, timePos: 45, volume: 55 },
+  });
+
+  await waitFor(() => expect(seekSlider).toHaveAttribute('aria-valuenow', '45'));
+  expect(screen.getByRole('slider', { name: 'Volume' })).toHaveAttribute('aria-valuenow', '55');
+  await waitFor(() =>
+    expect(getProperty.mock.calls.length).toBeGreaterThan(trackFetchesBeforePush),
+  );
 
   dispose();
   root.remove();


### PR DESCRIPTION
Mount one shell-level NowPlayingProvider for the Now Playing query and
Tauri event listener. The Sidebar trigger and the Now Playing controls
consume the same context state and cache entry, so pushed state can
never diverge between them; opening the drawer with both mounted
registers exactly one change listener, reopening it neither leaks nor
duplicates listeners, and disposal happens once with the authenticated
shell. Pushed changes still clear local seek/volume drafts and
invalidate track data through the owner's external-change registration.
The per-consumer createNowPlayingState factory is gone; focused shell
and card tests prove the observable single-owner behavior.

Closes #206

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>