### PR TITLE
refactor(library): complete the virtual window behind one geometry interface

### DIFF
--- a/src/routes/_authenticated/library/$collectionType/$libraryId.tsx
+++ b/src/routes/_authenticated/library/$collectionType/$libraryId.tsx
@@ -14,7 +14,6 @@ import LibrarySearchBar from '@components/LibrarySearchBar';
 import { Button } from '@components/ui';
 import { cx } from '@styled-system/css';
 import { createFileRoute, redirect } from '@tanstack/solid-router';
-import { createVirtualizer, observeElementRect } from '@tanstack/solid-virtual';
 import { Exit } from 'effect';
 import {
   ArrowDownWideNarrowIcon,
@@ -26,30 +25,14 @@ import {
   ListSortAscending,
   RefreshCw,
 } from 'lucide-solid';
-import {
-  For,
-  Show,
-  Suspense,
-  createEffect,
-  createMemo,
-  createSignal,
-  onCleanup,
-  onMount,
-} from 'solid-js';
+import { For, Show, Suspense, createEffect, createMemo, createSignal, onCleanup } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
-import { LIBRARY_BROWSE_PAGE_SIZE } from '~effects/library';
 import { librarySessionSignature } from '~effects/query';
 import type { LibrarySessionKey } from '~effects/query';
 import * as recipes from '~styles/recipes';
 import { createLibraryBrowseWindow } from '~utils/createLibraryBrowseWindow';
 import { createSharedLibraryFilters } from '~utils/createSharedLibraryFilters';
 import type { LibrarySortDirection } from '~utils/createSharedLibraryFilters';
-import {
-  libraryBrowseColumnCount,
-  libraryBrowseVirtualOverscanRows,
-  libraryBrowseVirtualRowHeight,
-} from '~utils/libraryBrowseLayout';
-import { libraryBrowsePageStartsForRows } from '~utils/libraryBrowsePageSelection';
 
 import { AUTHENTICATED_HOME_ROUTE } from '../../../../router-guards';
 import * as styles from '../browseRoute.styles';
@@ -74,13 +57,6 @@ function LibraryBrowseRoute() {
   const libraryFilters = createSharedLibraryFilters();
   const [autoLoadSentinel, setAutoLoadSentinel] = createSignal<HTMLDivElement | null>(null);
   const [autoLoadSentinelVisible, setAutoLoadSentinelVisible] = createSignal(false);
-  const [virtualGrid, setVirtualGrid] = createSignal<HTMLDivElement | null>(null);
-  const [virtualGridWidth, setVirtualGridWidth] = createSignal(1280);
-  const [virtualViewportHeight, setVirtualViewportHeight] = createSignal(720);
-  const [virtualizerMounted, setVirtualizerMounted] = createSignal(false);
-  const appScroll = useAppScrollArea();
-  const [virtualScrollMargin, setVirtualScrollMargin] = createSignal(0);
-  onMount(() => setVirtualizerMounted(true));
   const bootstrap = useAuthenticatedBootstrap();
   const sessionKey = bootstrap.sessionKey;
   const activeSessionSignature = createMemo(() => librarySessionSignature(sessionKey()));
@@ -114,121 +90,8 @@ function LibraryBrowseRoute() {
     }),
     filtersReady: libraryFilters.ready,
     sessionActive: isMountedSessionActive,
-    virtualPageStartsForCurrentWindow: () => virtualPageStartsForCurrentWindow(),
-    onIdentityReset: () => appScroll.scrollTo({ top: 0 }),
   });
 
-  const fallbackVirtualGridWidth = () => {
-    const gridWidth = virtualGrid()?.clientWidth ?? 0;
-    if (gridWidth > 0) {
-      return gridWidth;
-    }
-
-    const viewportWidth = appScroll.viewport()?.clientWidth ?? 0;
-    if (viewportWidth > 0) {
-      return viewportWidth;
-    }
-
-    if (typeof window !== 'undefined' && window.innerWidth > 0) {
-      return window.innerWidth;
-    }
-
-    return 1280;
-  };
-  const fallbackVirtualGridHeight = () => {
-    const viewportHeight = appScroll.viewport()?.clientHeight ?? 0;
-    if (viewportHeight > 0) {
-      return viewportHeight;
-    }
-
-    if (typeof window !== 'undefined' && window.innerHeight > 0) {
-      return window.innerHeight;
-    }
-
-    return 720;
-  };
-  const measureVirtualGrid = () => {
-    setVirtualGridWidth(fallbackVirtualGridWidth());
-    setVirtualViewportHeight(fallbackVirtualGridHeight());
-
-    const grid = virtualGrid();
-    const scrollElement = appScroll.viewport();
-    if (!grid || !scrollElement) {
-      setVirtualScrollMargin(0);
-      return;
-    }
-
-    setVirtualScrollMargin(
-      grid.getBoundingClientRect().top -
-        scrollElement.getBoundingClientRect().top +
-        scrollElement.scrollTop,
-    );
-  };
-  createEffect(() => {
-    const grid = virtualGrid();
-    const scrollElement = appScroll.viewport();
-    if (typeof ResizeObserver === 'undefined') {
-      measureVirtualGrid();
-      if (typeof window !== 'undefined') {
-        window.addEventListener('resize', measureVirtualGrid);
-        onCleanup(() => window.removeEventListener('resize', measureVirtualGrid));
-      }
-      return;
-    }
-
-    const observer = new ResizeObserver(measureVirtualGrid);
-    if (grid) {
-      observer.observe(grid);
-    }
-    if (scrollElement) {
-      observer.observe(scrollElement);
-    }
-    onCleanup(() => observer.disconnect());
-  });
-
-  const columnCount = createMemo(() => libraryBrowseColumnCount(virtualGridWidth()));
-  const virtualRowColumnIndexes = createMemo(() =>
-    Array.from({ length: columnCount() }, (_, index) => index),
-  );
-  const estimateVirtualRowHeight = () => libraryBrowseVirtualRowHeight(virtualGridWidth());
-  const rowVirtualizer = createVirtualizer<HTMLElement, HTMLDivElement>({
-    get count() {
-      return browseWindow.usesVirtualGrid()
-        ? Math.ceil(browseWindow.totalRecordCount() / columnCount())
-        : 0;
-    },
-    get enabled() {
-      return (
-        virtualizerMounted() && browseWindow.usesVirtualGrid() && appScroll.viewport() !== null
-      );
-    },
-    getScrollElement: () => appScroll.viewport(),
-    estimateSize: estimateVirtualRowHeight,
-    get overscan() {
-      return libraryBrowseVirtualOverscanRows(virtualViewportHeight(), estimateVirtualRowHeight());
-    },
-    observeElementRect: (instance, callback) =>
-      observeElementRect(instance, (rect) =>
-        callback({
-          width: rect.width || virtualGridWidth(),
-          height: rect.height || virtualViewportHeight(),
-        }),
-      ),
-    get initialRect() {
-      return { width: virtualGridWidth(), height: virtualViewportHeight() };
-    },
-    get scrollMargin() {
-      return virtualScrollMargin();
-    },
-  });
-  const virtualPageStartsForCurrentWindow = () =>
-    libraryBrowsePageStartsForRows({
-      rowIndexes: rowVirtualizer.getVirtualItems().map((virtualRow) => virtualRow.index),
-      columnCount: columnCount(),
-      totalRecordCount: browseWindow.totalRecordCount(),
-      pageSize: LIBRARY_BROWSE_PAGE_SIZE,
-      reverse: browseWindow.needsReverse(),
-    });
   const statusTitle = () => {
     const current = browseWindow.firstPage();
     if (!current) {
@@ -342,15 +205,17 @@ function LibraryBrowseRoute() {
                 </div>
               }
             >
-              <div ref={setVirtualGrid} data-testid="library-virtual-grid">
+              <div ref={browseWindow.virtual.ref} data-testid="library-virtual-grid">
                 <div
                   aria-label={`${libraryTitle(collectionType())} library items`}
-                  aria-rowcount={Math.ceil(browseWindow.totalRecordCount() / columnCount())}
+                  aria-rowcount={Math.ceil(
+                    browseWindow.totalRecordCount() / browseWindow.virtual.columnCount(),
+                  )}
                   class={styles.virtualCanvas}
                   role="grid"
-                  style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+                  style={{ height: `${browseWindow.virtual.totalSize()}px` }}
                 >
-                  <For each={rowVirtualizer.getVirtualItems()}>
+                  <For each={browseWindow.virtual.items()}>
                     {(virtualRow) => (
                       <div
                         aria-rowindex={virtualRow.index + 1}
@@ -358,14 +223,14 @@ function LibraryBrowseRoute() {
                         role="row"
                         style={{
                           height: `${virtualRow.size}px`,
-                          transform: `translateY(${virtualRow.start - virtualScrollMargin()}px)`,
+                          transform: `translateY(${virtualRow.start - browseWindow.virtual.scrollMargin()}px)`,
                         }}
                       >
                         <div class={styles.grid} role="presentation">
-                          <For each={virtualRowColumnIndexes()}>
+                          <For each={browseWindow.virtual.rowColumnIndexes()}>
                             {(columnIndex) => {
                               const displayIndex = () =>
-                                virtualRow.index * columnCount() + columnIndex;
+                                virtualRow.index * browseWindow.virtual.columnCount() + columnIndex;
                               const item = () => browseWindow.itemForDisplayIndex(displayIndex());
 
                               return (

--- a/src/utils/createLibraryBrowseWindow.ts
+++ b/src/utils/createLibraryBrowseWindow.ts
@@ -1,10 +1,12 @@
 /**
- * Route-owned Library Browser paging and cache module for both browse modes.
+ * Route-owned Library Browser virtual window module for both browse modes.
  *
  * Owns page-zero bootstrap, the normal-grid/virtual-mode decision,
  * random-access virtual window fetching, per-page cache bridging, identity
- * reset, and failed-page retry. The pure layout and page-selection utilities
- * remain internal seams; the route keeps rendering and (for now) geometry.
+ * reset, failed-page retry, and the virtual geometry: shared-viewport
+ * measurement, enablement, overscan, canvas height, and row placement. The
+ * pure layout and page-selection utilities remain internal seams; the route
+ * stays the rendering adapter.
  */
 import type {
   VideoLibraryItem,
@@ -13,15 +15,26 @@ import type {
   VideoLibraryPlayedFilter,
   VideoLibrarySort,
 } from '@bindings';
+import { useAppScrollArea } from '@components/AppScrollAreaContext';
 import { createInfiniteQuery, useQueryClient } from '@tanstack/solid-query';
+import { createVirtualizer, observeElementRect } from '@tanstack/solid-virtual';
+import type { VirtualItem } from '@tanstack/solid-virtual';
 import { Exit } from 'effect';
-import { createEffect, createMemo, createSignal } from 'solid-js';
+import { createEffect, createMemo, createSignal, onCleanup, onMount } from 'solid-js';
 import { commandFailureMessage } from '~effects/commands';
 import { LIBRARY_BROWSE_PAGE_SIZE, fetchVideoLibraryPage } from '~effects/library';
 import type { LibraryBrowseState, LibraryExit } from '~effects/library';
 import { queryKeys, runExit } from '~effects/query';
 import type { LibrarySessionKey } from '~effects/query';
-import { libraryBrowsePageLocationForDisplayIndex } from '~utils/libraryBrowsePageSelection';
+import {
+  libraryBrowseColumnCount,
+  libraryBrowseVirtualOverscanRows,
+  libraryBrowseVirtualRowHeight,
+} from '~utils/libraryBrowseLayout';
+import {
+  libraryBrowsePageLocationForDisplayIndex,
+  libraryBrowsePageStartsForRows,
+} from '~utils/libraryBrowsePageSelection';
 
 export const LIBRARY_VIRTUAL_TOTAL_THRESHOLD = 100;
 
@@ -48,10 +61,6 @@ export interface LibraryBrowseWindowOptions {
   readonly filtersReady: () => boolean;
   /** The mounted session still matches the current connection identity. */
   readonly sessionActive: () => boolean;
-  /** Page starts covering the current virtual window plus look-ahead. */
-  readonly virtualPageStartsForCurrentWindow: () => readonly number[];
-  /** Route-level reaction to identity changes (scroll reset). */
-  readonly onIdentityReset: () => void;
 }
 
 type LibraryBrowsePageFailure = LibraryExit<LibraryBrowseState> & { _tag: 'Failure' };
@@ -74,6 +83,21 @@ export interface LibraryBrowseWindow {
   readonly loadMoreErrorDescription: () => string | null;
   readonly loadMoreRetryBusy: () => boolean;
   readonly retryFailedPage: () => void;
+  /** Virtual geometry owned behind one interface; the route only renders it. */
+  readonly virtual: LibraryBrowseVirtualGeometry;
+}
+
+export interface LibraryBrowseVirtualGeometry {
+  /** Ref callback for the virtual root element. */
+  readonly ref: (element: HTMLDivElement | null) => void;
+  /** Rows currently rendered by the virtualizer. */
+  readonly items: () => VirtualItem[];
+  /** Full virtual canvas height in px. */
+  readonly totalSize: () => number;
+  /** Scroll offset of the virtual root inside the shared viewport. */
+  readonly scrollMargin: () => number;
+  readonly columnCount: () => number;
+  readonly rowColumnIndexes: () => readonly number[];
 }
 
 export function createLibraryBrowseWindow(
@@ -138,6 +162,8 @@ export function createLibraryBrowseWindow(
       }),
   }));
 
+  const appScroll = useAppScrollArea();
+
   // Identity reset: sort/filter/library/session changes clear virtual state,
   // reject in-flight completions via the signature check, and reset scroll.
   let activeBrowseQuerySignature = '';
@@ -146,7 +172,7 @@ export function createLibraryBrowseWindow(
     if (activeBrowseQuerySignature && activeBrowseQuerySignature !== nextSignature) {
       setVirtualPagesByStartIndex(new Map<number, LibraryExit<LibraryBrowseState>>());
       setVirtualPageStartsFetching(new Set<number>());
-      options.onIdentityReset();
+      appScroll.scrollTo({ top: 0 });
     }
     activeBrowseQuerySignature = nextSignature;
   });
@@ -300,7 +326,7 @@ export function createLibraryBrowseWindow(
       });
   };
   const fetchVisibleVirtualPages = (allowNetworkFetch: boolean) => {
-    for (const startIndex of options.virtualPageStartsForCurrentWindow()) {
+    for (const startIndex of virtualPageStartsForCurrentWindow()) {
       fetchVirtualPage(startIndex, allowNetworkFetch);
     }
   };
@@ -373,6 +399,132 @@ export function createLibraryBrowseWindow(
     void browseQuery.fetchNextPage({ cancelRefetch: false });
   };
 
+  // Virtual geometry: shared-viewport measurement, enablement, overscan,
+  // canvas height, and row placement behind one interface.
+  const [virtualGrid, setVirtualGrid] = createSignal<HTMLDivElement | null>(null);
+  const [virtualGridWidth, setVirtualGridWidth] = createSignal(1280);
+  const [virtualViewportHeight, setVirtualViewportHeight] = createSignal(720);
+  const [virtualizerMounted, setVirtualizerMounted] = createSignal(false);
+  const [virtualScrollMargin, setVirtualScrollMargin] = createSignal(0);
+  onMount(() => setVirtualizerMounted(true));
+
+  const fallbackVirtualGridWidth = () => {
+    const gridWidth = virtualGrid()?.clientWidth ?? 0;
+    if (gridWidth > 0) {
+      return gridWidth;
+    }
+
+    const viewportWidth = appScroll.viewport()?.clientWidth ?? 0;
+    if (viewportWidth > 0) {
+      return viewportWidth;
+    }
+
+    if (typeof window !== 'undefined' && window.innerWidth > 0) {
+      return window.innerWidth;
+    }
+
+    return 1280;
+  };
+  const fallbackVirtualGridHeight = () => {
+    const viewportHeight = appScroll.viewport()?.clientHeight ?? 0;
+    if (viewportHeight > 0) {
+      return viewportHeight;
+    }
+
+    if (typeof window !== 'undefined' && window.innerHeight > 0) {
+      return window.innerHeight;
+    }
+
+    return 720;
+  };
+  const measureVirtualGrid = () => {
+    setVirtualGridWidth(fallbackVirtualGridWidth());
+    setVirtualViewportHeight(fallbackVirtualGridHeight());
+
+    const grid = virtualGrid();
+    const scrollElement = appScroll.viewport();
+    if (!grid || !scrollElement) {
+      setVirtualScrollMargin(0);
+      return;
+    }
+
+    setVirtualScrollMargin(
+      grid.getBoundingClientRect().top -
+        scrollElement.getBoundingClientRect().top +
+        scrollElement.scrollTop,
+    );
+  };
+  createEffect(() => {
+    const grid = virtualGrid();
+    const scrollElement = appScroll.viewport();
+    if (typeof ResizeObserver === 'undefined') {
+      measureVirtualGrid();
+      if (typeof window !== 'undefined') {
+        window.addEventListener('resize', measureVirtualGrid);
+        onCleanup(() => window.removeEventListener('resize', measureVirtualGrid));
+      }
+      return;
+    }
+
+    const observer = new ResizeObserver(measureVirtualGrid);
+    if (grid) {
+      observer.observe(grid);
+    }
+    if (scrollElement) {
+      observer.observe(scrollElement);
+    }
+    onCleanup(() => observer.disconnect());
+  });
+
+  const columnCount = createMemo(() => libraryBrowseColumnCount(virtualGridWidth()));
+  const virtualRowColumnIndexes = createMemo(() =>
+    Array.from({ length: columnCount() }, (_, index) => index),
+  );
+  const estimateVirtualRowHeight = () => libraryBrowseVirtualRowHeight(virtualGridWidth());
+  const rowVirtualizer = createVirtualizer<HTMLElement, HTMLDivElement>({
+    get count() {
+      return usesVirtualGrid() ? Math.ceil(totalRecordCount() / columnCount()) : 0;
+    },
+    get enabled() {
+      return virtualizerMounted() && usesVirtualGrid() && appScroll.viewport() !== null;
+    },
+    getScrollElement: () => appScroll.viewport(),
+    estimateSize: estimateVirtualRowHeight,
+    get overscan() {
+      return libraryBrowseVirtualOverscanRows(virtualViewportHeight(), estimateVirtualRowHeight());
+    },
+    observeElementRect: (instance, callback) =>
+      observeElementRect(instance, (rect) =>
+        callback({
+          width: rect.width || virtualGridWidth(),
+          height: rect.height || virtualViewportHeight(),
+        }),
+      ),
+    get initialRect() {
+      return { width: virtualGridWidth(), height: virtualViewportHeight() };
+    },
+    get scrollMargin() {
+      return virtualScrollMargin();
+    },
+  });
+  const virtualPageStartsForCurrentWindow = () =>
+    libraryBrowsePageStartsForRows({
+      rowIndexes: rowVirtualizer.getVirtualItems().map((virtualRow) => virtualRow.index),
+      columnCount: columnCount(),
+      totalRecordCount: totalRecordCount(),
+      pageSize: LIBRARY_BROWSE_PAGE_SIZE,
+      reverse: needsReverse(),
+    });
+
+  const virtual: LibraryBrowseVirtualGeometry = {
+    ref: setVirtualGrid,
+    items: () => rowVirtualizer.getVirtualItems(),
+    totalSize: () => rowVirtualizer.getTotalSize(),
+    scrollMargin: virtualScrollMargin,
+    columnCount,
+    rowColumnIndexes: virtualRowColumnIndexes,
+  };
+
   return {
     readyState,
     totalRecordCount,
@@ -390,5 +542,6 @@ export function createLibraryBrowseWindow(
     loadMoreErrorDescription,
     loadMoreRetryBusy,
     retryFailedPage,
+    virtual,
   };
 }


### PR DESCRIPTION
Extend the Library Browser window module to own virtual geometry:
shared-viewport measurement, enablement, overscan, canvas height, and
row placement, while the route becomes a rendering adapter over the
module's virtual interface. The virtualizer still activates only after
Solid mount, virtual mode, and a real shared viewport; overscan stays
adaptive within 6-18 rows with a six-row fallback for invalid geometry;
the canvas keeps full height with scroll-margin row placement and no
entrance fade on the virtual root. The native offset observer and the
no-blank-frame contract are preserved, proven by the shell blanking
tests and the focused native WebView virtual-scroll spec. The
ADR-governed Library Image Cache is untouched.

Closes #208

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>